### PR TITLE
Feature/renaming keep both methods option

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ repositories {
 dependencies {
     compile fileTree(dir: 'dependencies', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
+    testCompile 'org.assertj:assertj-core:3.11.0'
 }
 
 // the lines bellow deal with exporting a running jar

--- a/src/main/java/br/ufpe/cin/app/JFSTMerge.java
+++ b/src/main/java/br/ufpe/cin/app/JFSTMerge.java
@@ -61,6 +61,9 @@ public class JFSTMerge {
 	@Parameter(names = "-l", description = "Parameter to disable logging of merged files (true or false).",arity = 1)
 	public static boolean logFiles = true;
 
+	@Parameter(names = "-rn", description = "Parameter to enable keeping both methods on renaming conflicts.",arity = 1)
+	public static boolean keepOldRenamedMethod = false;
+
 	/**
 	 * Merges merge scenarios, indicated by .revisions files. 
 	 * This is mainly used for evaluation purposes.
@@ -157,6 +160,7 @@ public class JFSTMerge {
 		}
 
 		MergeContext context = new MergeContext(left, base, right, outputFilePath);
+		context.keepOldRenamedMethod = keepOldRenamedMethod;
 
 		//there is no need to call specific merge algorithms in equal or consistenly changes files (fast-forward merge)
 		if (FilesManager.areFilesDifferent(left, base, right, outputFilePath, context)) {

--- a/src/main/java/br/ufpe/cin/app/JFSTMerge.java
+++ b/src/main/java/br/ufpe/cin/app/JFSTMerge.java
@@ -61,8 +61,8 @@ public class JFSTMerge {
 	@Parameter(names = "-l", description = "Parameter to disable logging of merged files (true or false).",arity = 1)
 	public static boolean logFiles = true;
 
-	@Parameter(names = "-rn", description = "Parameter to enable keeping both methods on renaming conflicts.",arity = 1)
-	public static boolean keepOldRenamedMethod = false;
+	@Parameter(names = "-rn", description = "Parameter to enable keeping both methods on renaming conflicts.")
+	public static boolean keepBothVersionsOfRenamedMethod = false;
 
 	/**
 	 * Merges merge scenarios, indicated by .revisions files. 
@@ -160,7 +160,7 @@ public class JFSTMerge {
 		}
 
 		MergeContext context = new MergeContext(left, base, right, outputFilePath);
-		context.keepOldRenamedMethod = keepOldRenamedMethod;
+		context.keepBothVersionsOfRenamedMethod = keepBothVersionsOfRenamedMethod;
 
 		//there is no need to call specific merge algorithms in equal or consistenly changes files (fast-forward merge)
 		if (FilesManager.areFilesDifferent(left, base, right, outputFilePath, context)) {

--- a/src/main/java/br/ufpe/cin/app/JFSTMerge.java
+++ b/src/main/java/br/ufpe/cin/app/JFSTMerge.java
@@ -160,7 +160,6 @@ public class JFSTMerge {
 		}
 
 		MergeContext context = new MergeContext(left, base, right, outputFilePath);
-		context.keepBothVersionsOfRenamedMethod = keepBothVersionsOfRenamedMethod;
 
 		//there is no need to call specific merge algorithms in equal or consistenly changes files (fast-forward merge)
 		if (FilesManager.areFilesDifferent(left, base, right, outputFilePath, context)) {

--- a/src/main/java/br/ufpe/cin/mergers/handlers/RenamingConflictsHandler.java
+++ b/src/main/java/br/ufpe/cin/mergers/handlers/RenamingConflictsHandler.java
@@ -20,13 +20,12 @@ import java.util.stream.Collectors;
  */
 public final class RenamingConflictsHandler {
     private static final double BODY_SIMILARITY_THRESHOLD = 0.7;  //a typical value of 0.7 (up to 1.0) is used, increase it for a more accurate comparison, or decrease for a more relaxed one.
-    private static final boolean KEEP_BOTH_METHODS = false; //TODO make this a configurable parameter
 
     private enum RenamingSide {LEFT, RIGHT}
 
     public static void handle(MergeContext context) {
         //when both developers rename the same method/constructor
-        if (!KEEP_BOTH_METHODS) handleMutualRenamings(context);
+        if (!context.keepOldRenamedMethod) handleMutualRenamings(context);
 
         //when one of the developers rename a method/constructor
         handleSingleRenamings(context);
@@ -81,7 +80,7 @@ public final class RenamingConflictsHandler {
             MergeConflict mergeConflict = FilesManager.extractMergeConflicts(currentNodeContent).get(0);
             String oppositeSideNodeContent = getMergeConflictContentOfOppositeSide(mergeConflict, renamingSide);
 
-            if (KEEP_BOTH_METHODS) {
+            if (context.keepOldRenamedMethod) {
                 ((FSTTerminal) tuple.getRight()).setBody(oppositeSideNodeContent);
                 continue;
             }

--- a/src/main/java/br/ufpe/cin/mergers/handlers/RenamingConflictsHandler.java
+++ b/src/main/java/br/ufpe/cin/mergers/handlers/RenamingConflictsHandler.java
@@ -1,5 +1,6 @@
 package br.ufpe.cin.mergers.handlers;
 
+import br.ufpe.cin.app.JFSTMerge;
 import br.ufpe.cin.files.FilesManager;
 import br.ufpe.cin.mergers.util.MergeConflict;
 import br.ufpe.cin.mergers.util.MergeContext;
@@ -25,7 +26,7 @@ public final class RenamingConflictsHandler {
 
     public static void handle(MergeContext context) {
         //when both developers rename the same method/constructor
-        if (!context.keepBothVersionsOfRenamedMethod) handleMutualRenamings(context);
+        if (!JFSTMerge.keepBothVersionsOfRenamedMethod) handleMutualRenamings(context);
 
         //when one of the developers rename a method/constructor
         handleSingleRenamings(context);
@@ -80,7 +81,7 @@ public final class RenamingConflictsHandler {
             MergeConflict mergeConflict = FilesManager.extractMergeConflicts(currentNodeContent).get(0);
             String oppositeSideNodeContent = getMergeConflictContentOfOppositeSide(mergeConflict, renamingSide);
 
-            if (context.keepBothVersionsOfRenamedMethod) {
+            if (JFSTMerge.keepBothVersionsOfRenamedMethod) {
                 ((FSTTerminal) tuple.getRight()).setBody(oppositeSideNodeContent);
                 continue;
             }

--- a/src/main/java/br/ufpe/cin/mergers/handlers/RenamingConflictsHandler.java
+++ b/src/main/java/br/ufpe/cin/mergers/handlers/RenamingConflictsHandler.java
@@ -57,7 +57,7 @@ public final class RenamingConflictsHandler {
     }
 
     private static String removeSignature(String string) {
-        string = string.replaceFirst("^.*(?=(\\{))", "");
+        string = string.replaceFirst("^.[^{]*(?=(\\{))", "");
         return string;
     }
 

--- a/src/main/java/br/ufpe/cin/mergers/handlers/RenamingConflictsHandler.java
+++ b/src/main/java/br/ufpe/cin/mergers/handlers/RenamingConflictsHandler.java
@@ -107,7 +107,7 @@ public final class RenamingConflictsHandler {
 
             if (hasUnstructuredMergeConflict) {
                 String possibleRenamingContent = getMostSimilarContent(similarNodes);
-                generateRenamingConflict(context, currentNodeContent, possibleRenamingContent, oppositeSideNodeContent, false);
+                generateRenamingConflict(context, currentNodeContent, possibleRenamingContent, oppositeSideNodeContent, renamingSide);
             } else { //do not report the renaming conflict
                 ((FSTTerminal) tuple.getRight()).setBody(oppositeSideNodeContent);
             }
@@ -147,8 +147,8 @@ public final class RenamingConflictsHandler {
         return false;
     }
 
-    private static void generateRenamingConflict(MergeContext context, String currentNodeContent, String firstContent, String secondContent, boolean isLeftToRight) {
-        if (!isLeftToRight) {//managing the origin of the changes in the conflict
+    private static void generateRenamingConflict(MergeContext context, String currentNodeContent, String firstContent, String secondContent, RenamingSide renamingSide) {
+        if (renamingSide == RenamingSide.LEFT) {//managing the origin of the changes in the conflict
             String aux = secondContent;
             secondContent = firstContent;
             firstContent = aux;
@@ -165,7 +165,7 @@ public final class RenamingConflictsHandler {
         MergeConflict newConflict = new MergeConflict(firstContent + '\n', secondContent + '\n');
         //second put the conflict in one of the nodes containing the previous conflict, and deletes the other node containing the possible renamed version
         FilesManager.findAndReplaceASTNodeContent(context.superImposedTree, currentNodeContent, newConflict.body);
-        if (isLeftToRight) {
+        if (renamingSide == RenamingSide.RIGHT) {
             FilesManager.findAndDeleteASTNode(context.superImposedTree, firstContent);
         } else {
             FilesManager.findAndDeleteASTNode(context.superImposedTree, secondContent);

--- a/src/main/java/br/ufpe/cin/mergers/handlers/RenamingConflictsHandler.java
+++ b/src/main/java/br/ufpe/cin/mergers/handlers/RenamingConflictsHandler.java
@@ -183,82 +183,10 @@ public final class RenamingConflictsHandler {
         FilesManager.findAndDeleteASTNode(context.superImposedTree, secondContent);
     }
 
-    /*	pure similarity-based handler (it works)
-
-     public static void handle(MergeContext context) {
-        //possible renamings or deletions in left
-        if(!context.possibleRenamedLeftNodes.isEmpty() || !context.possibleRenamedRightNodes.isEmpty()){
-            for(Pair<String,FSTNode> tuple: context.possibleRenamedLeftNodes){
-                List<Pair<Double,String>> similarNodes = new ArrayList<Pair<Double,String>>(); //list of possible nodes renaming a previous one
-                if(nodeHasConflict(tuple.getRight())){
-                    String baseContent = tuple.getLeft();
-                    String currentNodeContent= ((FSTTerminal) tuple.getRight()).getBody(); //node content with conflict
-                    String editedNodeContent = FilesManager.extractMergeConflicts(currentNodeContent).get(0).right;
-                    for(FSTNode newNode : context.addedLeftNodes){ // a possible renamed node is seem as "new" node due to superimposition
-                        if(isMethodOrConstructorNode(newNode)){
-                            String possibleRenamingContent = ((FSTTerminal) newNode).getBody();
-                            double similarity  	  		   = FilesManager.computeStringSimilarity(baseContent, possibleRenamingContent);
-                            if(similarity >= 0.7){ //a typical value of 0.7 (up to 1.0) is used, increase it for a more accurate comparison, or decrease for a more relaxed one.
-                                Pair<Double,String> tp = Pair.of(similarity, possibleRenamingContent);
-                                similarNodes.add(tp);
-                            }
-                        }
-                    }
-                    if(similarNodes.isEmpty()){//there is no similar node. it is a possible deletion, so remove the conflict keeping the edited version of the content
-                        FilesManager.findAndReplaceASTNodeContent(context.superImposedTree, currentNodeContent,editedNodeContent);
-
-                        //statistics
-                        context.deletionConflicts++;
-                    } else {
-                        String possibleRenamingContent = getMostSimilarContent(similarNodes);
-                        generateRenamingConflict(context, currentNodeContent, possibleRenamingContent, editedNodeContent,true);
-                    }
-                }
-            }
-
-            //possible renamings or deletions in right
-            for(Pair<String,FSTNode> tuple: context.possibleRenamedRightNodes){
-                List<Pair<Double,String>> similarNodes = new ArrayList<Pair<Double,String>>(); //list of possible nodes renaming a previous one
-                if(nodeHasConflict(tuple.getRight())){
-                    String baseContent = tuple.getLeft();
-                    String currentNodeContent= ((FSTTerminal) tuple.getRight()).getBody(); //node content with conflict
-                    String editedNodeContent = FilesManager.extractMergeConflicts(currentNodeContent).get(0).left;
-                    for(FSTNode newNode : context.addedRightNodes){ // a possible renamed node is seem as "new" node due to superimposition
-                        if(isMethodOrConstructorNode(newNode)){
-                            String possibleRenamingContent = ((FSTTerminal) newNode).getBody();
-                            double similarity  	  		   = FilesManager.computeStringSimilarity(baseContent, possibleRenamingContent);
-                            if(similarity >= 0.7){ //a typical value of 0.7 (up to 1.0) is used, increase it for a more accurate comparison, or decrease for a more relaxed one.
-                                Pair<Double,String> tp = Pair.of(similarity, possibleRenamingContent);
-                                similarNodes.add(tp);
-                            }
-                        }
-                    }
-                    if(similarNodes.isEmpty()){//there is no similar node. it is a possible deletion, so remove the conflict keeping the edited version of the content
-                        FilesManager.findAndReplaceASTNodeContent(context.superImposedTree, currentNodeContent,editedNodeContent);
-
-                        //statistics
-                        context.deletionConflicts++;
-                    } else {
-                        String possibleRenamingContent = getMostSimilarContent(similarNodes);
-                        generateRenamingConflict(context, currentNodeContent, possibleRenamingContent, editedNodeContent,false);
-                    }
-                }
-            }
-        }
-    }
-     */
-
     private static String getMergeConflictContentOfOppositeSide(MergeConflict mergeConflict, RenamingSide side) {
         if (side == RenamingSide.LEFT) return mergeConflict.right;
         if (side == RenamingSide.RIGHT) return mergeConflict.left;
 
         return null;
-    }
-
-    public static void main(String[] args) {
-        String s = "intsum(inta,intb){returna+b;}";
-        removeSignature(s);
-        System.out.println(s);
-
     }
 }

--- a/src/main/java/br/ufpe/cin/mergers/handlers/RenamingConflictsHandler.java
+++ b/src/main/java/br/ufpe/cin/mergers/handlers/RenamingConflictsHandler.java
@@ -1,273 +1,272 @@
 package br.ufpe.cin.mergers.handlers;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.apache.commons.lang3.tuple.Pair;
-
 import br.ufpe.cin.files.FilesManager;
 import br.ufpe.cin.mergers.util.MergeConflict;
 import br.ufpe.cin.mergers.util.MergeContext;
 import de.ovgu.cide.fstgen.ast.FSTNode;
 import de.ovgu.cide.fstgen.ast.FSTTerminal;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Renaming or deletions conflicts happen when one developer edits a element renamed or deleted by other.
  * Semistructured merge is unable to detect such cases because it matches elements via its identifier, so
  * if a element is renamed or deleted it cannot match the elements anymore. This class overcomes this issue.
- * @author Guilherme
  *
+ * @author Guilherme
  */
 public final class RenamingConflictsHandler {
 
-	public static void handle(MergeContext context) {
-		//when both developers rename the same method/constructor
-		handleMutualRenamings(context);
+    public static void handle(MergeContext context) {
+        //when both developers rename the same method/constructor
+        handleMutualRenamings(context);
 
-		//when one of the developers rename a method/constructor
-		handleSingleRenamings(context);
-	}
+        //when one of the developers rename a method/constructor
+        handleSingleRenamings(context);
+    }
 
-	private static void handleMutualRenamings(MergeContext context) {
-		if(!context.addedLeftNodes.isEmpty() && !context.addedRightNodes.isEmpty()){
-			List<FSTNode> leftNewMethodsOrConstructors  = context.addedLeftNodes.stream().filter(m -> isValidNode(m)).collect(Collectors.toList());
-			List<FSTNode> rightNewMethodsOrConstructors= context.addedRightNodes.stream().filter(m -> isValidNode(m)).collect(Collectors.toList());
-			for(FSTNode left : leftNewMethodsOrConstructors){
-				for(FSTNode right : rightNewMethodsOrConstructors){
-					if(!left.getName().equals(right.getName())){ //only if the two declarations have different signatures
-						String leftBody = ((FSTTerminal)left).getBody();
-						leftBody = FilesManager.getStringContentIntoSingleLineNoSpacing(leftBody);
-						leftBody = removeSignature(leftBody);
+    private static void handleMutualRenamings(MergeContext context) {
+        if (!context.addedLeftNodes.isEmpty() && !context.addedRightNodes.isEmpty()) {
+            List<FSTNode> leftNewMethodsOrConstructors = context.addedLeftNodes.stream().filter(m -> isValidNode(m)).collect(Collectors.toList());
+            List<FSTNode> rightNewMethodsOrConstructors = context.addedRightNodes.stream().filter(m -> isValidNode(m)).collect(Collectors.toList());
+            for (FSTNode left : leftNewMethodsOrConstructors) {
+                for (FSTNode right : rightNewMethodsOrConstructors) {
+                    if (!left.getName().equals(right.getName())) { //only if the two declarations have different signatures
+                        String leftBody = ((FSTTerminal) left).getBody();
+                        leftBody = FilesManager.getStringContentIntoSingleLineNoSpacing(leftBody);
+                        leftBody = removeSignature(leftBody);
 
-						String rightBody = ((FSTTerminal)right).getBody();
-						rightBody = FilesManager.getStringContentIntoSingleLineNoSpacing(rightBody);
-						rightBody = removeSignature(rightBody);
+                        String rightBody = ((FSTTerminal) right).getBody();
+                        rightBody = FilesManager.getStringContentIntoSingleLineNoSpacing(rightBody);
+                        rightBody = removeSignature(rightBody);
 
-						if(leftBody.equals(rightBody)){//the methods have the same body, ignoring their signature
-							generateMutualRenamingConflict(context, ((FSTTerminal)left).getBody(), ((FSTTerminal)left).getBody(), ((FSTTerminal)right).getBody());
-							break;
-						}
-					}
-				}
-			}
-		}
-	}
+                        if (leftBody.equals(rightBody)) {//the methods have the same body, ignoring their signature
+                            generateMutualRenamingConflict(context, ((FSTTerminal) left).getBody(), ((FSTTerminal) left).getBody(), ((FSTTerminal) right).getBody());
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
 
-	private static String removeSignature(String string) {
-		string = string.replaceFirst("^.*(?=(\\{))", "");
-		return string;
-	}
+    private static String removeSignature(String string) {
+        string = string.replaceFirst("^.*(?=(\\{))", "");
+        return string;
+    }
 
-	private static void handleSingleRenamings(MergeContext context) {
-		//possible renamings or deletions in left
-		if(!context.possibleRenamedLeftNodes.isEmpty() || !context.possibleRenamedRightNodes.isEmpty()){
-			for(Pair<String,FSTNode> tuple: context.possibleRenamedLeftNodes){
-				List<Pair<Double,String>> similarNodes = new ArrayList<Pair<Double,String>>(); //list of possible nodes renaming a previous one
-				if(nodeHasConflict(tuple.getRight()) && isValidNode(tuple.getRight())){
-					String baseContent = tuple.getLeft();
-					String currentNodeContent= ((FSTTerminal) tuple.getRight()).getBody(); //node content with conflict
-					String editedNodeContent = FilesManager.extractMergeConflicts(currentNodeContent).get(0).right;
+    private static void handleSingleRenamings(MergeContext context) {
+        //possible renamings or deletions in left
+        if (!context.possibleRenamedLeftNodes.isEmpty() || !context.possibleRenamedRightNodes.isEmpty()) {
+            for (Pair<String, FSTNode> tuple : context.possibleRenamedLeftNodes) {
+                List<Pair<Double, String>> similarNodes = new ArrayList<Pair<Double, String>>(); //list of possible nodes renaming a previous one
+                if (nodeHasConflict(tuple.getRight()) && isValidNode(tuple.getRight())) {
+                    String baseContent = tuple.getLeft();
+                    String currentNodeContent = ((FSTTerminal) tuple.getRight()).getBody(); //node content with conflict
+                    String editedNodeContent = FilesManager.extractMergeConflicts(currentNodeContent).get(0).right;
 
-					//1. getting similar nodes to fulfill renaming conflicts
-					for(FSTNode newNode : context.addedLeftNodes){ // a possible renamed node is seem as "new" node due to superimposition
-						if(isValidNode(newNode)){
-							String possibleRenamingContent = ((FSTTerminal) newNode).getBody();
-							double similarity  	  		   = FilesManager.computeStringSimilarity(baseContent, possibleRenamingContent);
-							if(similarity >= 0.7){ //a typical value of 0.7 (up to 1.0) is used, increase it for a more accurate comparison, or decrease for a more relaxed one.
-								Pair<Double,String> tp = Pair.of(similarity, possibleRenamingContent);
-								similarNodes.add(tp);
-							}
-						}
-					}
+                    //1. getting similar nodes to fulfill renaming conflicts
+                    for (FSTNode newNode : context.addedLeftNodes) { // a possible renamed node is seem as "new" node due to superimposition
+                        if (isValidNode(newNode)) {
+                            String possibleRenamingContent = ((FSTTerminal) newNode).getBody();
+                            double similarity = FilesManager.computeStringSimilarity(baseContent, possibleRenamingContent);
+                            if (similarity >= 0.7) { //a typical value of 0.7 (up to 1.0) is used, increase it for a more accurate comparison, or decrease for a more relaxed one.
+                                Pair<Double, String> tp = Pair.of(similarity, possibleRenamingContent);
+                                similarNodes.add(tp);
+                            }
+                        }
+                    }
 
-					//2. checking if unstructured merge also reported the renaming conflict
-					String signature = getSignature(baseContent);
-					List<MergeConflict> unstructuredMergeConflictsHavingRenamedSignature = FilesManager.extractMergeConflicts(context.unstructuredOutput).stream()
-							.filter(mc -> FilesManager.getStringContentIntoSingleLineNoSpacing(mc.body).contains(signature))
-							.collect(Collectors.toList());
-					if(unstructuredMergeConflictsHavingRenamedSignature.size() > 0){
-						String possibleRenamingContent = getMostSimilarContent(similarNodes);
-						generateRenamingConflict(context, currentNodeContent, possibleRenamingContent, editedNodeContent,false);
-					} else { //do not report the renaming conflict
-						((FSTTerminal) tuple.getRight()).setBody(editedNodeContent);
-					}
-				}
-			}
+                    //2. checking if unstructured merge also reported the renaming conflict
+                    String signature = getSignature(baseContent);
+                    List<MergeConflict> unstructuredMergeConflictsHavingRenamedSignature = FilesManager.extractMergeConflicts(context.unstructuredOutput).stream()
+                            .filter(mc -> FilesManager.getStringContentIntoSingleLineNoSpacing(mc.body).contains(signature))
+                            .collect(Collectors.toList());
+                    if (unstructuredMergeConflictsHavingRenamedSignature.size() > 0) {
+                        String possibleRenamingContent = getMostSimilarContent(similarNodes);
+                        generateRenamingConflict(context, currentNodeContent, possibleRenamingContent, editedNodeContent, false);
+                    } else { //do not report the renaming conflict
+                        ((FSTTerminal) tuple.getRight()).setBody(editedNodeContent);
+                    }
+                }
+            }
 
-			//possible renamings or deletions in right
-			for(Pair<String,FSTNode> tuple: context.possibleRenamedRightNodes){
-				List<Pair<Double,String>> similarNodes = new ArrayList<Pair<Double,String>>(); //list of possible nodes renaming a previous one
-				if(nodeHasConflict(tuple.getRight()) && isValidNode(tuple.getRight())){
-					String baseContent = tuple.getLeft();
-					String currentNodeContent= ((FSTTerminal) tuple.getRight()).getBody(); //node content with conflict
-					String editedNodeContent = FilesManager.extractMergeConflicts(currentNodeContent).get(0).left;
+            //possible renamings or deletions in right
+            for (Pair<String, FSTNode> tuple : context.possibleRenamedRightNodes) {
+                List<Pair<Double, String>> similarNodes = new ArrayList<Pair<Double, String>>(); //list of possible nodes renaming a previous one
+                if (nodeHasConflict(tuple.getRight()) && isValidNode(tuple.getRight())) {
+                    String baseContent = tuple.getLeft();
+                    String currentNodeContent = ((FSTTerminal) tuple.getRight()).getBody(); //node content with conflict
+                    String editedNodeContent = FilesManager.extractMergeConflicts(currentNodeContent).get(0).left;
 
-					for(FSTNode newNode : context.addedRightNodes){ // a possible renamed node is seem as "new" node due to superimposition
-						if(isValidNode(newNode)){
-							String possibleRenamingContent = ((FSTTerminal) newNode).getBody();
-							double similarity  	  		   = FilesManager.computeStringSimilarity(baseContent, possibleRenamingContent);
-							if(similarity >= 0.7){ //a typical value of 0.7 (up to 1.0) is used, increase it for a more accurate comparison, or decrease for a more relaxed one.
-								Pair<Double,String> tp = Pair.of(similarity, possibleRenamingContent);
-								similarNodes.add(tp);
-							}
-						}
-					}
+                    for (FSTNode newNode : context.addedRightNodes) { // a possible renamed node is seem as "new" node due to superimposition
+                        if (isValidNode(newNode)) {
+                            String possibleRenamingContent = ((FSTTerminal) newNode).getBody();
+                            double similarity = FilesManager.computeStringSimilarity(baseContent, possibleRenamingContent);
+                            if (similarity >= 0.7) { //a typical value of 0.7 (up to 1.0) is used, increase it for a more accurate comparison, or decrease for a more relaxed one.
+                                Pair<Double, String> tp = Pair.of(similarity, possibleRenamingContent);
+                                similarNodes.add(tp);
+                            }
+                        }
+                    }
 
-					String signature = getSignature(baseContent);
-					List<MergeConflict> unstructuredMergeConflictsHavingRenamedSignature = FilesManager.extractMergeConflicts(context.unstructuredOutput).stream()
-							.filter(mc -> FilesManager.getStringContentIntoSingleLineNoSpacing(mc.body).contains(signature))
-							.collect(Collectors.toList());
-					if(unstructuredMergeConflictsHavingRenamedSignature.size() > 0){
-						String possibleRenamingContent = getMostSimilarContent(similarNodes);
-						generateRenamingConflict(context, currentNodeContent, possibleRenamingContent, editedNodeContent,false);
-					} else { //do not report the renaming conflict
-						((FSTTerminal) tuple.getRight()).setBody(editedNodeContent);
-					}
-				}
-			}
-		}
-	}
+                    String signature = getSignature(baseContent);
+                    List<MergeConflict> unstructuredMergeConflictsHavingRenamedSignature = FilesManager.extractMergeConflicts(context.unstructuredOutput).stream()
+                            .filter(mc -> FilesManager.getStringContentIntoSingleLineNoSpacing(mc.body).contains(signature))
+                            .collect(Collectors.toList());
+                    if (unstructuredMergeConflictsHavingRenamedSignature.size() > 0) {
+                        String possibleRenamingContent = getMostSimilarContent(similarNodes);
+                        generateRenamingConflict(context, currentNodeContent, possibleRenamingContent, editedNodeContent, false);
+                    } else { //do not report the renaming conflict
+                        ((FSTTerminal) tuple.getRight()).setBody(editedNodeContent);
+                    }
+                }
+            }
+        }
+    }
 
-	private static String getSignature(String source) {
-		String trim = FilesManager.getStringContentIntoSingleLineNoSpacing(source);
-		String signatureTrimmed = trim.substring(0, (/*is interface?*/(trim.contains("{")) ? trim.indexOf("{") : trim.indexOf(";")));
-		return signatureTrimmed;
-	}
+    private static String getSignature(String source) {
+        String trim = FilesManager.getStringContentIntoSingleLineNoSpacing(source);
+        String signatureTrimmed = trim.substring(0, (/*is interface?*/(trim.contains("{")) ? trim.indexOf("{") : trim.indexOf(";")));
+        return signatureTrimmed;
+    }
 
-	private static String getMostSimilarContent(List<Pair<Double, String>> similarNodes) {
-		if(!similarNodes.isEmpty()){
-			similarNodes.sort((n1, n2) -> n1.getLeft().compareTo(n2.getLeft()));		
-			return (similarNodes.get(similarNodes.size()-1)).getRight();// the top of the list
-		} else {
-			return "";
-		}
-	}
+    private static String getMostSimilarContent(List<Pair<Double, String>> similarNodes) {
+        if (!similarNodes.isEmpty()) {
+            similarNodes.sort((n1, n2) -> n1.getLeft().compareTo(n2.getLeft()));
+            return (similarNodes.get(similarNodes.size() - 1)).getRight();// the top of the list
+        } else {
+            return "";
+        }
+    }
 
-	private static boolean nodeHasConflict(FSTNode node) {
-		if(isValidNode(node)){
-			String body = ((FSTTerminal) node).getBody();
-			return body.contains("<<<<<<< MINE");
-		}
-		return false;
-	}
+    private static boolean nodeHasConflict(FSTNode node) {
+        if (isValidNode(node)) {
+            String body = ((FSTTerminal) node).getBody();
+            return body.contains("<<<<<<< MINE");
+        }
+        return false;
+    }
 
-	private static boolean isValidNode(FSTNode node) {
-		if(node instanceof FSTTerminal){
-			String nodeType = ((FSTTerminal)node).getType();
-			if(nodeType.equals("MethodDecl") || nodeType.equals("ConstructorDecl")){
-				return true;
-			}
-		}
-		return false;
-	}
+    private static boolean isValidNode(FSTNode node) {
+        if (node instanceof FSTTerminal) {
+            String nodeType = ((FSTTerminal) node).getType();
+            if (nodeType.equals("MethodDecl") || nodeType.equals("ConstructorDecl")) {
+                return true;
+            }
+        }
+        return false;
+    }
 
-	private static void generateRenamingConflict(MergeContext context,String currentNodeContent, String firstContent,String secondContent, boolean isLeftToRight) {
-		if(!isLeftToRight){//managing the origin of the changes in the conflict
-			String aux 	 = secondContent;
-			secondContent= firstContent;
-			firstContent = aux;
-		}
+    private static void generateRenamingConflict(MergeContext context, String currentNodeContent, String firstContent, String secondContent, boolean isLeftToRight) {
+        if (!isLeftToRight) {//managing the origin of the changes in the conflict
+            String aux = secondContent;
+            secondContent = firstContent;
+            firstContent = aux;
+        }
 
-		//statistics
-		if(firstContent.isEmpty() || secondContent.isEmpty()){
-			context.deletionConflicts++;
-		} else {
-			context.renamingConflicts++;
-		}
+        //statistics
+        if (firstContent.isEmpty() || secondContent.isEmpty()) {
+            context.deletionConflicts++;
+        } else {
+            context.renamingConflicts++;
+        }
 
-		//first creates a conflict 
-		MergeConflict newConflict = new MergeConflict(firstContent+'\n', secondContent+'\n');
-		//second put the conflict in one of the nodes containing the previous conflict, and deletes the other node containing the possible renamed version
-		FilesManager.findAndReplaceASTNodeContent(context.superImposedTree, currentNodeContent, newConflict.body);
-		if(isLeftToRight){
-			FilesManager.findAndDeleteASTNode(context.superImposedTree, firstContent);
-		} else {
-			FilesManager.findAndDeleteASTNode(context.superImposedTree, secondContent);
+        //first creates a conflict
+        MergeConflict newConflict = new MergeConflict(firstContent + '\n', secondContent + '\n');
+        //second put the conflict in one of the nodes containing the previous conflict, and deletes the other node containing the possible renamed version
+        FilesManager.findAndReplaceASTNodeContent(context.superImposedTree, currentNodeContent, newConflict.body);
+        if (isLeftToRight) {
+            FilesManager.findAndDeleteASTNode(context.superImposedTree, firstContent);
+        } else {
+            FilesManager.findAndDeleteASTNode(context.superImposedTree, secondContent);
 
-		}
-	}
+        }
+    }
 
-	private static void generateMutualRenamingConflict(MergeContext context,String currentNodeContent, String firstContent,String secondContent) {
-		//statistics
-		context.renamingConflicts++;
+    private static void generateMutualRenamingConflict(MergeContext context, String currentNodeContent, String firstContent, String secondContent) {
+        //statistics
+        context.renamingConflicts++;
 
-		//first creates a conflict 
-		MergeConflict newConflict = new MergeConflict(firstContent+'\n', secondContent+'\n');
+        //first creates a conflict
+        MergeConflict newConflict = new MergeConflict(firstContent + '\n', secondContent + '\n');
 
-		//second put the conflict in one of the nodes containing the previous conflict, and deletes the other node containing the possible renamed version
-		FilesManager.findAndReplaceASTNodeContent(context.superImposedTree, currentNodeContent, newConflict.body);
-		FilesManager.findAndDeleteASTNode(context.superImposedTree, secondContent);
-	}
+        //second put the conflict in one of the nodes containing the previous conflict, and deletes the other node containing the possible renamed version
+        FilesManager.findAndReplaceASTNodeContent(context.superImposedTree, currentNodeContent, newConflict.body);
+        FilesManager.findAndDeleteASTNode(context.superImposedTree, secondContent);
+    }
 
-	/*	pure similarity-based handler (it works)
+    /*	pure similarity-based handler (it works)
 
- 	public static void handle(MergeContext context) {
-		//possible renamings or deletions in left
-		if(!context.possibleRenamedLeftNodes.isEmpty() || !context.possibleRenamedRightNodes.isEmpty()){
-			for(Pair<String,FSTNode> tuple: context.possibleRenamedLeftNodes){
-				List<Pair<Double,String>> similarNodes = new ArrayList<Pair<Double,String>>(); //list of possible nodes renaming a previous one
-				if(nodeHasConflict(tuple.getRight())){
-					String baseContent = tuple.getLeft();
-					String currentNodeContent= ((FSTTerminal) tuple.getRight()).getBody(); //node content with conflict
-					String editedNodeContent = FilesManager.extractMergeConflicts(currentNodeContent).get(0).right;
-					for(FSTNode newNode : context.addedLeftNodes){ // a possible renamed node is seem as "new" node due to superimposition
-						if(isValidNode(newNode)){
-							String possibleRenamingContent = ((FSTTerminal) newNode).getBody();
-							double similarity  	  		   = FilesManager.computeStringSimilarity(baseContent, possibleRenamingContent);
-							if(similarity >= 0.7){ //a typical value of 0.7 (up to 1.0) is used, increase it for a more accurate comparison, or decrease for a more relaxed one.
-								Pair<Double,String> tp = Pair.of(similarity, possibleRenamingContent);
-								similarNodes.add(tp);
-							}
-						}
-					}
-					if(similarNodes.isEmpty()){//there is no similar node. it is a possible deletion, so remove the conflict keeping the edited version of the content 
-						FilesManager.findAndReplaceASTNodeContent(context.superImposedTree, currentNodeContent,editedNodeContent);
+     public static void handle(MergeContext context) {
+        //possible renamings or deletions in left
+        if(!context.possibleRenamedLeftNodes.isEmpty() || !context.possibleRenamedRightNodes.isEmpty()){
+            for(Pair<String,FSTNode> tuple: context.possibleRenamedLeftNodes){
+                List<Pair<Double,String>> similarNodes = new ArrayList<Pair<Double,String>>(); //list of possible nodes renaming a previous one
+                if(nodeHasConflict(tuple.getRight())){
+                    String baseContent = tuple.getLeft();
+                    String currentNodeContent= ((FSTTerminal) tuple.getRight()).getBody(); //node content with conflict
+                    String editedNodeContent = FilesManager.extractMergeConflicts(currentNodeContent).get(0).right;
+                    for(FSTNode newNode : context.addedLeftNodes){ // a possible renamed node is seem as "new" node due to superimposition
+                        if(isValidNode(newNode)){
+                            String possibleRenamingContent = ((FSTTerminal) newNode).getBody();
+                            double similarity  	  		   = FilesManager.computeStringSimilarity(baseContent, possibleRenamingContent);
+                            if(similarity >= 0.7){ //a typical value of 0.7 (up to 1.0) is used, increase it for a more accurate comparison, or decrease for a more relaxed one.
+                                Pair<Double,String> tp = Pair.of(similarity, possibleRenamingContent);
+                                similarNodes.add(tp);
+                            }
+                        }
+                    }
+                    if(similarNodes.isEmpty()){//there is no similar node. it is a possible deletion, so remove the conflict keeping the edited version of the content
+                        FilesManager.findAndReplaceASTNodeContent(context.superImposedTree, currentNodeContent,editedNodeContent);
 
-						//statistics
-						context.deletionConflicts++;
-					} else {
-						String possibleRenamingContent = getMostSimilarContent(similarNodes);
-						generateRenamingConflict(context, currentNodeContent, possibleRenamingContent, editedNodeContent,true);
-					}
-				}
-			}
+                        //statistics
+                        context.deletionConflicts++;
+                    } else {
+                        String possibleRenamingContent = getMostSimilarContent(similarNodes);
+                        generateRenamingConflict(context, currentNodeContent, possibleRenamingContent, editedNodeContent,true);
+                    }
+                }
+            }
 
-			//possible renamings or deletions in right
-			for(Pair<String,FSTNode> tuple: context.possibleRenamedRightNodes){
-				List<Pair<Double,String>> similarNodes = new ArrayList<Pair<Double,String>>(); //list of possible nodes renaming a previous one
-				if(nodeHasConflict(tuple.getRight())){
-					String baseContent = tuple.getLeft();
-					String currentNodeContent= ((FSTTerminal) tuple.getRight()).getBody(); //node content with conflict
-					String editedNodeContent = FilesManager.extractMergeConflicts(currentNodeContent).get(0).left;
-					for(FSTNode newNode : context.addedRightNodes){ // a possible renamed node is seem as "new" node due to superimposition
-						if(isValidNode(newNode)){
-							String possibleRenamingContent = ((FSTTerminal) newNode).getBody();
-							double similarity  	  		   = FilesManager.computeStringSimilarity(baseContent, possibleRenamingContent);
-							if(similarity >= 0.7){ //a typical value of 0.7 (up to 1.0) is used, increase it for a more accurate comparison, or decrease for a more relaxed one.
-								Pair<Double,String> tp = Pair.of(similarity, possibleRenamingContent);
-								similarNodes.add(tp);
-							}
-						}
-					}
-					if(similarNodes.isEmpty()){//there is no similar node. it is a possible deletion, so remove the conflict keeping the edited version of the content 
-						FilesManager.findAndReplaceASTNodeContent(context.superImposedTree, currentNodeContent,editedNodeContent);
+            //possible renamings or deletions in right
+            for(Pair<String,FSTNode> tuple: context.possibleRenamedRightNodes){
+                List<Pair<Double,String>> similarNodes = new ArrayList<Pair<Double,String>>(); //list of possible nodes renaming a previous one
+                if(nodeHasConflict(tuple.getRight())){
+                    String baseContent = tuple.getLeft();
+                    String currentNodeContent= ((FSTTerminal) tuple.getRight()).getBody(); //node content with conflict
+                    String editedNodeContent = FilesManager.extractMergeConflicts(currentNodeContent).get(0).left;
+                    for(FSTNode newNode : context.addedRightNodes){ // a possible renamed node is seem as "new" node due to superimposition
+                        if(isValidNode(newNode)){
+                            String possibleRenamingContent = ((FSTTerminal) newNode).getBody();
+                            double similarity  	  		   = FilesManager.computeStringSimilarity(baseContent, possibleRenamingContent);
+                            if(similarity >= 0.7){ //a typical value of 0.7 (up to 1.0) is used, increase it for a more accurate comparison, or decrease for a more relaxed one.
+                                Pair<Double,String> tp = Pair.of(similarity, possibleRenamingContent);
+                                similarNodes.add(tp);
+                            }
+                        }
+                    }
+                    if(similarNodes.isEmpty()){//there is no similar node. it is a possible deletion, so remove the conflict keeping the edited version of the content
+                        FilesManager.findAndReplaceASTNodeContent(context.superImposedTree, currentNodeContent,editedNodeContent);
 
-						//statistics
-						context.deletionConflicts++;
-					} else {
-						String possibleRenamingContent = getMostSimilarContent(similarNodes);
-						generateRenamingConflict(context, currentNodeContent, possibleRenamingContent, editedNodeContent,false);
-					}
-				}
-			}
-		}
-	}
-	 */
-	public static void main(String[] args) {
-		String s = "intsum(inta,intb){returna+b;}";
-		removeSignature(s);
-		System.out.println(s);
+                        //statistics
+                        context.deletionConflicts++;
+                    } else {
+                        String possibleRenamingContent = getMostSimilarContent(similarNodes);
+                        generateRenamingConflict(context, currentNodeContent, possibleRenamingContent, editedNodeContent,false);
+                    }
+                }
+            }
+        }
+    }
+     */
+    public static void main(String[] args) {
+        String s = "intsum(inta,intb){returna+b;}";
+        removeSignature(s);
+        System.out.println(s);
 
-	}
+    }
 }

--- a/src/main/java/br/ufpe/cin/mergers/handlers/RenamingConflictsHandler.java
+++ b/src/main/java/br/ufpe/cin/mergers/handlers/RenamingConflictsHandler.java
@@ -25,7 +25,7 @@ public final class RenamingConflictsHandler {
 
     public static void handle(MergeContext context) {
         //when both developers rename the same method/constructor
-        if (!context.keepOldRenamedMethod) handleMutualRenamings(context);
+        if (!context.keepBothVersionsOfRenamedMethod) handleMutualRenamings(context);
 
         //when one of the developers rename a method/constructor
         handleSingleRenamings(context);
@@ -80,7 +80,7 @@ public final class RenamingConflictsHandler {
             MergeConflict mergeConflict = FilesManager.extractMergeConflicts(currentNodeContent).get(0);
             String oppositeSideNodeContent = getMergeConflictContentOfOppositeSide(mergeConflict, renamingSide);
 
-            if (context.keepOldRenamedMethod) {
+            if (context.keepBothVersionsOfRenamedMethod) {
                 ((FSTTerminal) tuple.getRight()).setBody(oppositeSideNodeContent);
                 continue;
             }

--- a/src/main/java/br/ufpe/cin/mergers/util/MergeContext.java
+++ b/src/main/java/br/ufpe/cin/mergers/util/MergeContext.java
@@ -65,7 +65,7 @@ public class MergeContext {
 	public int equalConflicts     = 0;
 
 	//configurations
-	public boolean keepOldRenamedMethod = false;
+	public boolean keepBothVersionsOfRenamedMethod = false;
 	
 	public MergeContext(){
 	}

--- a/src/main/java/br/ufpe/cin/mergers/util/MergeContext.java
+++ b/src/main/java/br/ufpe/cin/mergers/util/MergeContext.java
@@ -16,7 +16,7 @@ import de.ovgu.cide.fstgen.ast.FSTNode;
  * @author Guilherme
  */
 public class MergeContext {
-	File base;
+    File base;
 	File right;
 	File left;
 	String outputFilePath;
@@ -63,7 +63,9 @@ public class MergeContext {
 	public int orderingConflicts 			   = 0;
 	public int duplicatedDeclarationErrors	   = 0;
 	public int equalConflicts     = 0;
-	
+
+	//configurations
+	public boolean keepOldRenamedMethod = false;
 	
 	public MergeContext(){
 	}

--- a/src/main/java/br/ufpe/cin/mergers/util/MergeContext.java
+++ b/src/main/java/br/ufpe/cin/mergers/util/MergeContext.java
@@ -64,9 +64,6 @@ public class MergeContext {
 	public int duplicatedDeclarationErrors	   = 0;
 	public int equalConflicts     = 0;
 
-	//configurations
-	public boolean keepBothVersionsOfRenamedMethod = false;
-	
 	public MergeContext(){
 	}
 

--- a/src/test/java/br/ufpe/cin/mergers/handlers/RenamingConflictsHandlerTest.java
+++ b/src/test/java/br/ufpe/cin/mergers/handlers/RenamingConflictsHandlerTest.java
@@ -1,95 +1,98 @@
 package br.ufpe.cin.mergers.handlers;
 
-import static org.junit.Assert.*;
+import br.ufpe.cin.app.JFSTMerge;
+import br.ufpe.cin.files.FilesManager;
+import br.ufpe.cin.mergers.util.MergeContext;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 import java.io.File;
 import java.io.OutputStream;
 import java.io.PrintStream;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import br.ufpe.cin.app.JFSTMerge;
-import br.ufpe.cin.files.FilesManager;
-import br.ufpe.cin.mergers.util.MergeContext;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class RenamingConflictsHandlerTest {
-	
-	@BeforeClass
-	public static void setUpBeforeClass() throws Exception {
-		//hidding sysout output
-		@SuppressWarnings("unused")
-		PrintStream originalStream = System.out;
-		PrintStream hideStream    = new PrintStream(new OutputStream(){
-		    public void write(int b) {}
-		});
-		System.setOut(hideStream);
-	}
-	
-	@Test
-	public void testConflictingRenamingInLeft() {
-		MergeContext ctx = 	new JFSTMerge().mergeFiles(
-				new File("testfiles/renamingmethodleftconf/left.java"), 
-				new File("testfiles/renamingmethodleftconf/base.java"), 
-				new File("testfiles/renamingmethodleftconf/right.java"),
-				null);
-		String mergeResult = FilesManager.getStringContentIntoSingleLineNoSpacing(ctx.semistructuredOutput);
-		
-		assertTrue(mergeResult.contains("<<<<<<<MINEpublicvoidm(){inta;}=======publicvoidn(){}>>>>>>>YOURS"));
-		assertTrue(ctx.renamingConflicts == 1);
-	}
+    private File baseFile = new File("testfiles/renaming/method/base_method/Test.java");
+    private File bodyChangedFileBelowSignature = new File("testfiles/renaming/method/changed_body_below_signature/Test.java");
+    private File bodyChangedAtEndFile = new File("testfiles/renaming/method/changed_body_at_end/Test.java");
+    private File renamedMethodFile1 = new File("testfiles/renaming/method/renamed_method_1/Test.java");
+    private File renamedMethodFile2 = new File("testfiles/renaming/method/renamed_method_2/Test.java");
 
-	@Test
-	public void testConflictingRenamingInRight() {
-		MergeContext ctx = 	new JFSTMerge().mergeFiles(
-				new File("testfiles/renamingmethodrightconf/left.java"), 
-				new File("testfiles/renamingmethodrightconf/base.java"), 
-				new File("testfiles/renamingmethodrightconf/right.java"),
-				null);
-		String mergeResult = FilesManager.getStringContentIntoSingleLineNoSpacing(ctx.semistructuredOutput);
-		
-		assertTrue(mergeResult.contains("<<<<<<<MINEpublicvoidm(){inta;}=======publicvoidn(){}>>>>>>>YOURS"));
-		assertTrue(ctx.renamingConflicts == 1);
-	}
-	
-	@Test
-	public void testNoConflictingRenamingInLeft() {
-		MergeContext ctx = 	new JFSTMerge().mergeFiles(
-				new File("testfiles/renamingmethodleftnoconf/left.java"), 
-				new File("testfiles/renamingmethodleftnoconf/base.java"), 
-				new File("testfiles/renamingmethodleftnoconf/right.java"),
-				null);
-		String mergeResult = FilesManager.getStringContentIntoSingleLineNoSpacing(ctx.semistructuredOutput);
-		
-		assertTrue(!mergeResult.contains("(cause:possiblerenaming)"));
-		assertTrue(ctx.renamingConflicts == 0);
-	}
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        //hidding sysout output
+        @SuppressWarnings("unused")
+        PrintStream originalStream = System.out;
+        PrintStream hideStream = new PrintStream(new OutputStream() {
+            public void write(int b) {
+            }
+        });
+        System.setOut(hideStream);
+    }
 
-	@Test
-	public void testNoConflictingRenamingInRight() {
-		MergeContext ctx = 	new JFSTMerge().mergeFiles(
-				new File("testfiles/renamingmethodrightnoconf/left.java"), 
-				new File("testfiles/renamingmethodrightnoconf/base.java"), 
-				new File("testfiles/renamingmethodrightnoconf/right.java"),
-				null);
-		String mergeResult = FilesManager.getStringContentIntoSingleLineNoSpacing(ctx.semistructuredOutput);
-		
-		assertTrue(!mergeResult.contains("(cause:possiblerenaming)"));
-		assertTrue(ctx.renamingConflicts == 0);
-	}
-	
-	@Test
-	public void testConflictingRenamingMutual() {
-		MergeContext ctx = 	new JFSTMerge().mergeFiles(
-				new File("testfiles/renamingmutual/left.java"), 
-				new File("testfiles/renamingmutual/base.java"), 
-				new File("testfiles/renamingmutual/right.java"),
-				null);
-		String mergeResult = FilesManager.getStringContentIntoSingleLineNoSpacing(ctx.semistructuredOutput);
-		
-		assertTrue(mergeResult.contains("<<<<<<<MINEintsum(inta,intb){returna+b;}=======intmySum(inta,intb){returna+b;}>>>>>>>YOURS"));
-		assertTrue(ctx.renamingConflicts == 1);
-	}
-	
+    @Test
+    public void testMethodRenamingOnLeft_whenOneVersionRenamesMethod_andOtherVersionChangesBodyBelowSignature_shouldReportConflict() {
+        MergeContext ctx = new JFSTMerge().mergeFiles(
+                renamedMethodFile1,
+                baseFile,
+                bodyChangedFileBelowSignature,
+                null);
+        String mergeResult = FilesManager.getStringContentIntoSingleLineNoSpacing(ctx.semistructuredOutput);
 
+        assertThat(mergeResult).contains("<<<<<<<MINEpublicvoidm(){inta=123;}=======publicvoidn1(){inta;}>>>>>>>YOURS");
+        assertThat(ctx.renamingConflicts).isOne();
+    }
+
+    @Test
+    public void testMethodRenamingOnRight_whenOneVersionRenamesMethod_andOtherVersionChangesBodyBelowSignature_shouldReportConflict() {
+        MergeContext ctx = new JFSTMerge().mergeFiles(
+                bodyChangedFileBelowSignature,
+                baseFile,
+                renamedMethodFile1,
+                null);
+        String mergeResult = FilesManager.getStringContentIntoSingleLineNoSpacing(ctx.semistructuredOutput);
+
+        assertThat(mergeResult).contains("<<<<<<<MINEpublicvoidm(){inta=123;}=======publicvoidn1(){inta;}>>>>>>>YOURS");
+        assertThat(ctx.renamingConflicts).isOne();
+    }
+
+    @Test
+    public void testMethodRenamingOnLeft_whenOneVersionRenamesMethod_andOtherVersionChangesBodyAtEnd_shouldNotReportConflict() {
+        MergeContext ctx = new JFSTMerge().mergeFiles(
+                renamedMethodFile1,
+                baseFile,
+                bodyChangedAtEndFile,
+                null);
+        String mergeResult = FilesManager.getStringContentIntoSingleLineNoSpacing(ctx.semistructuredOutput);
+
+        assertThat(mergeResult).doesNotContain("(cause:possiblerenaming)");
+        assertThat(ctx.renamingConflicts).isZero();
+    }
+
+    @Test
+    public void testMethodRenamingOnRight_whenOneVersionRenamesMethod_andOtherVersionChangesBodyAtEnd_shouldNotReportConflict() {
+        MergeContext ctx = new JFSTMerge().mergeFiles(
+                bodyChangedAtEndFile,
+                baseFile,
+                renamedMethodFile1,
+                null);
+        String mergeResult = FilesManager.getStringContentIntoSingleLineNoSpacing(ctx.semistructuredOutput);
+
+        assertThat(mergeResult).doesNotContain("(cause:possiblerenaming)");
+        assertThat(ctx.renamingConflicts).isZero();
+    }
+
+    @Test
+    public void testMethodRenamingMutual_whenBothVersionRenamesMethodDifferently_shouldReportConflict() {
+        MergeContext ctx = new JFSTMerge().mergeFiles(
+                renamedMethodFile1,
+                baseFile,
+                renamedMethodFile2,
+                null);
+        String mergeResult = FilesManager.getStringContentIntoSingleLineNoSpacing(ctx.semistructuredOutput);
+
+        assertThat(mergeResult).contains("<<<<<<<MINEpublicvoidn1(){inta;}=======publicvoidn2(){inta;}>>>>>>>YOURS");
+        assertThat(ctx.renamingConflicts).isOne();
+    }
 }

--- a/src/test/java/br/ufpe/cin/mergers/handlers/RenamingConflictsHandlerTest.java
+++ b/src/test/java/br/ufpe/cin/mergers/handlers/RenamingConflictsHandlerTest.java
@@ -33,7 +33,7 @@ public class RenamingConflictsHandlerTest {
 
     @Test
     public void testMethodRenamingOnLeft_whenLeftRenamesMethod_andRightChangesBodyBelowSignature_shouldReportConflict() {
-        JFSTMerge.keepOldRenamedMethod = false;
+        JFSTMerge.keepBothVersionsOfRenamedMethod = false;
 
         MergeContext ctx = new JFSTMerge().mergeFiles(
                 renamedMethodFile1,
@@ -48,7 +48,7 @@ public class RenamingConflictsHandlerTest {
 
     @Test
     public void testMethodRenamingOnRight_whenRightRenamesMethod_andLeftChangesBodyBelowSignature_shouldReportConflict() {
-        JFSTMerge.keepOldRenamedMethod = false;
+        JFSTMerge.keepBothVersionsOfRenamedMethod = false;
 
         MergeContext ctx = new JFSTMerge().mergeFiles(
                 bodyChangedFileBelowSignature,
@@ -63,7 +63,7 @@ public class RenamingConflictsHandlerTest {
 
     @Test
     public void testMethodRenamingOnLeft_whenLeftRenamesMethod_andRightChangesBodyAtEnd_shouldNotReportConflict() {
-        JFSTMerge.keepOldRenamedMethod = false;
+        JFSTMerge.keepBothVersionsOfRenamedMethod = false;
 
         MergeContext ctx = new JFSTMerge().mergeFiles(
                 renamedMethodFile1,
@@ -78,7 +78,7 @@ public class RenamingConflictsHandlerTest {
 
     @Test
     public void testMethodRenamingOnRight_whenLeftRenamesMethod_andRightnChangesBodyAtEnd_shouldNotReportConflict() {
-        JFSTMerge.keepOldRenamedMethod = false;
+        JFSTMerge.keepBothVersionsOfRenamedMethod = false;
 
         MergeContext ctx = new JFSTMerge().mergeFiles(
                 bodyChangedAtEndFile,
@@ -93,7 +93,7 @@ public class RenamingConflictsHandlerTest {
 
     @Test
     public void testMutualMethodRenaming_whenBothVersionsRenamesMethodDifferently_shouldReportConflict() {
-        JFSTMerge.keepOldRenamedMethod = false;
+        JFSTMerge.keepBothVersionsOfRenamedMethod = false;
 
         MergeContext ctx = new JFSTMerge().mergeFiles(
                 renamedMethodFile1,
@@ -108,7 +108,7 @@ public class RenamingConflictsHandlerTest {
 
     @Test
     public void testMethodRenamingOnLeft_givenKeepBothMethodsIsEnabled_whenLeftRenamesMethod_andRightChangesBodyBelowSignature_shouldReportConflict() {
-        JFSTMerge.keepOldRenamedMethod = true;
+        JFSTMerge.keepBothVersionsOfRenamedMethod = true;
 
         MergeContext ctx = new JFSTMerge().mergeFiles(
                 renamedMethodFile1,
@@ -123,7 +123,7 @@ public class RenamingConflictsHandlerTest {
 
     @Test
     public void testMethodRenamingOnRight_givenKeepBothMethodsIsEnabled_whenRightRenamesMethod_andLeftChangesBodyBelowSignature_shouldNotReportConflict() {
-        JFSTMerge.keepOldRenamedMethod = true;
+        JFSTMerge.keepBothVersionsOfRenamedMethod = true;
 
         MergeContext ctx = new JFSTMerge().mergeFiles(
                 bodyChangedFileBelowSignature,
@@ -138,7 +138,7 @@ public class RenamingConflictsHandlerTest {
 
     @Test
     public void testMethodRenamingOnLeft_givenKeepBothMethodsIsEnabled_whenLeftRenamesMethod_andRightChangesBodyAtEnd_shouldNotReportConflict() {
-        JFSTMerge.keepOldRenamedMethod = true;
+        JFSTMerge.keepBothVersionsOfRenamedMethod = true;
 
         MergeContext ctx = new JFSTMerge().mergeFiles(
                 renamedMethodFile1,
@@ -153,7 +153,7 @@ public class RenamingConflictsHandlerTest {
 
     @Test
     public void testMethodRenamingOnRight_givenKeepBothMethodsIsEnabled_whenLeftRenamesMethod_andRightnChangesBodyAtEnd_shouldNotReportConflict() {
-        JFSTMerge.keepOldRenamedMethod = true;
+        JFSTMerge.keepBothVersionsOfRenamedMethod = true;
 
         MergeContext ctx = new JFSTMerge().mergeFiles(
                 bodyChangedAtEndFile,
@@ -168,7 +168,7 @@ public class RenamingConflictsHandlerTest {
 
     @Test
     public void testMutualMethodRenaming_givenKeepBothMethodsIsEnabled_whenBothVersionsRenameMethodDifferently_shouldNotReportConflict() {
-        JFSTMerge.keepOldRenamedMethod = true;
+        JFSTMerge.keepBothVersionsOfRenamedMethod = true;
 
         MergeContext ctx = new JFSTMerge().mergeFiles(
                 renamedMethodFile1,

--- a/src/test/java/br/ufpe/cin/mergers/handlers/RenamingConflictsHandlerTest.java
+++ b/src/test/java/br/ufpe/cin/mergers/handlers/RenamingConflictsHandlerTest.java
@@ -32,7 +32,7 @@ public class RenamingConflictsHandlerTest {
     }
 
     @Test
-    public void testMethodRenamingOnLeft_whenOneVersionRenamesMethod_andOtherVersionChangesBodyBelowSignature_shouldReportConflict() {
+    public void testMethodRenamingOnLeft_whenLeftRenamesMethod_andRightChangesBodyBelowSignature_shouldReportConflict() {
         MergeContext ctx = new JFSTMerge().mergeFiles(
                 renamedMethodFile1,
                 baseFile,
@@ -45,7 +45,7 @@ public class RenamingConflictsHandlerTest {
     }
 
     @Test
-    public void testMethodRenamingOnRight_whenOneVersionRenamesMethod_andOtherVersionChangesBodyBelowSignature_shouldReportConflict() {
+    public void testMethodRenamingOnRight_whenRightRenamesMethod_andLeftChangesBodyBelowSignature_shouldReportConflict() {
         MergeContext ctx = new JFSTMerge().mergeFiles(
                 bodyChangedFileBelowSignature,
                 baseFile,
@@ -53,12 +53,12 @@ public class RenamingConflictsHandlerTest {
                 null);
         String mergeResult = FilesManager.getStringContentIntoSingleLineNoSpacing(ctx.semistructuredOutput);
 
-        assertThat(mergeResult).contains("<<<<<<<MINEpublicvoidm(){inta=123;}=======publicvoidn1(){inta;}>>>>>>>YOURS");
+        assertThat(mergeResult).contains("<<<<<<<MINEpublicvoidn1(){inta;}=======publicvoidm(){inta=123;}>>>>>>>YOURS");
         assertThat(ctx.renamingConflicts).isOne();
     }
 
     @Test
-    public void testMethodRenamingOnLeft_whenOneVersionRenamesMethod_andOtherVersionChangesBodyAtEnd_shouldNotReportConflict() {
+    public void testMethodRenamingOnLeft_whenLeftRenamesMethod_andRightChangesBodyAtEnd_shouldNotReportConflict() {
         MergeContext ctx = new JFSTMerge().mergeFiles(
                 renamedMethodFile1,
                 baseFile,
@@ -71,7 +71,7 @@ public class RenamingConflictsHandlerTest {
     }
 
     @Test
-    public void testMethodRenamingOnRight_whenOneVersionRenamesMethod_andOtherVersionChangesBodyAtEnd_shouldNotReportConflict() {
+    public void testMethodRenamingOnRight_whenLeftRenamesMethod_andRightnChangesBodyAtEnd_shouldNotReportConflict() {
         MergeContext ctx = new JFSTMerge().mergeFiles(
                 bodyChangedAtEndFile,
                 baseFile,
@@ -84,7 +84,7 @@ public class RenamingConflictsHandlerTest {
     }
 
     @Test
-    public void testMethodRenamingMutual_whenBothVersionRenamesMethodDifferently_shouldReportConflict() {
+    public void testMethodRenamingMutual_whenBothVersionsRenamesMethodDifferently_shouldReportConflict() {
         MergeContext ctx = new JFSTMerge().mergeFiles(
                 renamedMethodFile1,
                 baseFile,

--- a/src/test/java/br/ufpe/cin/mergers/handlers/RenamingConflictsHandlerTest.java
+++ b/src/test/java/br/ufpe/cin/mergers/handlers/RenamingConflictsHandlerTest.java
@@ -33,6 +33,8 @@ public class RenamingConflictsHandlerTest {
 
     @Test
     public void testMethodRenamingOnLeft_whenLeftRenamesMethod_andRightChangesBodyBelowSignature_shouldReportConflict() {
+        JFSTMerge.keepOldRenamedMethod = false;
+
         MergeContext ctx = new JFSTMerge().mergeFiles(
                 renamedMethodFile1,
                 baseFile,
@@ -46,6 +48,8 @@ public class RenamingConflictsHandlerTest {
 
     @Test
     public void testMethodRenamingOnRight_whenRightRenamesMethod_andLeftChangesBodyBelowSignature_shouldReportConflict() {
+        JFSTMerge.keepOldRenamedMethod = false;
+
         MergeContext ctx = new JFSTMerge().mergeFiles(
                 bodyChangedFileBelowSignature,
                 baseFile,
@@ -59,6 +63,8 @@ public class RenamingConflictsHandlerTest {
 
     @Test
     public void testMethodRenamingOnLeft_whenLeftRenamesMethod_andRightChangesBodyAtEnd_shouldNotReportConflict() {
+        JFSTMerge.keepOldRenamedMethod = false;
+
         MergeContext ctx = new JFSTMerge().mergeFiles(
                 renamedMethodFile1,
                 baseFile,
@@ -72,6 +78,8 @@ public class RenamingConflictsHandlerTest {
 
     @Test
     public void testMethodRenamingOnRight_whenLeftRenamesMethod_andRightnChangesBodyAtEnd_shouldNotReportConflict() {
+        JFSTMerge.keepOldRenamedMethod = false;
+
         MergeContext ctx = new JFSTMerge().mergeFiles(
                 bodyChangedAtEndFile,
                 baseFile,
@@ -84,7 +92,9 @@ public class RenamingConflictsHandlerTest {
     }
 
     @Test
-    public void testMethodRenamingMutual_whenBothVersionsRenamesMethodDifferently_shouldReportConflict() {
+    public void testMutualMethodRenaming_whenBothVersionsRenamesMethodDifferently_shouldReportConflict() {
+        JFSTMerge.keepOldRenamedMethod = false;
+
         MergeContext ctx = new JFSTMerge().mergeFiles(
                 renamedMethodFile1,
                 baseFile,
@@ -94,5 +104,80 @@ public class RenamingConflictsHandlerTest {
 
         assertThat(mergeResult).contains("<<<<<<<MINEpublicvoidn1(){inta;}=======publicvoidn2(){inta;}>>>>>>>YOURS");
         assertThat(ctx.renamingConflicts).isOne();
+    }
+
+    @Test
+    public void testMethodRenamingOnLeft_givenKeepBothMethodsIsEnabled_whenLeftRenamesMethod_andRightChangesBodyBelowSignature_shouldReportConflict() {
+        JFSTMerge.keepOldRenamedMethod = true;
+
+        MergeContext ctx = new JFSTMerge().mergeFiles(
+                renamedMethodFile1,
+                baseFile,
+                bodyChangedFileBelowSignature,
+                null);
+        String mergeResult = FilesManager.getStringContentIntoSingleLineNoSpacing(ctx.semistructuredOutput);
+
+        assertThat(mergeResult).doesNotContain("(cause:possiblerenaming)");
+        assertThat(ctx.renamingConflicts).isZero();
+    }
+
+    @Test
+    public void testMethodRenamingOnRight_givenKeepBothMethodsIsEnabled_whenRightRenamesMethod_andLeftChangesBodyBelowSignature_shouldNotReportConflict() {
+        JFSTMerge.keepOldRenamedMethod = true;
+
+        MergeContext ctx = new JFSTMerge().mergeFiles(
+                bodyChangedFileBelowSignature,
+                baseFile,
+                renamedMethodFile1,
+                null);
+        String mergeResult = FilesManager.getStringContentIntoSingleLineNoSpacing(ctx.semistructuredOutput);
+
+        assertThat(mergeResult).doesNotContain("(cause:possiblerenaming)");
+        assertThat(ctx.renamingConflicts).isZero();
+    }
+
+    @Test
+    public void testMethodRenamingOnLeft_givenKeepBothMethodsIsEnabled_whenLeftRenamesMethod_andRightChangesBodyAtEnd_shouldNotReportConflict() {
+        JFSTMerge.keepOldRenamedMethod = true;
+
+        MergeContext ctx = new JFSTMerge().mergeFiles(
+                renamedMethodFile1,
+                baseFile,
+                bodyChangedAtEndFile,
+                null);
+        String mergeResult = FilesManager.getStringContentIntoSingleLineNoSpacing(ctx.semistructuredOutput);
+
+        assertThat(mergeResult).doesNotContain("(cause:possiblerenaming)");
+        assertThat(ctx.renamingConflicts).isZero();
+    }
+
+    @Test
+    public void testMethodRenamingOnRight_givenKeepBothMethodsIsEnabled_whenLeftRenamesMethod_andRightnChangesBodyAtEnd_shouldNotReportConflict() {
+        JFSTMerge.keepOldRenamedMethod = true;
+
+        MergeContext ctx = new JFSTMerge().mergeFiles(
+                bodyChangedAtEndFile,
+                baseFile,
+                renamedMethodFile1,
+                null);
+        String mergeResult = FilesManager.getStringContentIntoSingleLineNoSpacing(ctx.semistructuredOutput);
+
+        assertThat(mergeResult).doesNotContain("(cause:possiblerenaming)");
+        assertThat(ctx.renamingConflicts).isZero();
+    }
+
+    @Test
+    public void testMutualMethodRenaming_givenKeepBothMethodsIsEnabled_whenBothVersionsRenameMethodDifferently_shouldNotReportConflict() {
+        JFSTMerge.keepOldRenamedMethod = true;
+
+        MergeContext ctx = new JFSTMerge().mergeFiles(
+                renamedMethodFile1,
+                baseFile,
+                renamedMethodFile2,
+                null);
+        String mergeResult = FilesManager.getStringContentIntoSingleLineNoSpacing(ctx.semistructuredOutput);
+
+        assertThat(mergeResult).doesNotContain("(cause:possiblerenaming)");
+        assertThat(ctx.renamingConflicts).isZero();
     }
 }

--- a/testfiles/renaming/method/base_method/Test.java
+++ b/testfiles/renaming/method/base_method/Test.java
@@ -1,0 +1,7 @@
+public class Test {
+	
+	public void m()	{
+		int a;
+	}
+
+}

--- a/testfiles/renaming/method/changed_body_at_end/Test.java
+++ b/testfiles/renaming/method/changed_body_at_end/Test.java
@@ -1,0 +1,8 @@
+public class Test {
+	
+	public void m()	{
+		int a;
+		a = 123;
+	}
+
+}

--- a/testfiles/renaming/method/changed_body_below_signature/Test.java
+++ b/testfiles/renaming/method/changed_body_below_signature/Test.java
@@ -1,0 +1,7 @@
+public class Test {
+	
+	public void m()	{
+		int a = 123;
+	}
+
+}

--- a/testfiles/renaming/method/renamed_method_1/Test.java
+++ b/testfiles/renaming/method/renamed_method_1/Test.java
@@ -1,0 +1,7 @@
+public class Test {
+	
+	public void n1()	{
+		int a;
+	}
+
+}

--- a/testfiles/renaming/method/renamed_method_2/Test.java
+++ b/testfiles/renaming/method/renamed_method_2/Test.java
@@ -1,0 +1,7 @@
+public class Test {
+	
+	public void n2()	{
+		int a;
+	}
+
+}


### PR DESCRIPTION
This PR address the following changes:
- Adds option to keep both methods on renamings #17 
- Refactors RenamingConflictsHandler for better legibility
- Refactors RenamingConflictsHandler tests for better legibility
- Fixes #35 (_Order of revisions currently not respected on renamings_)

With keep both methods option enabled (`-rn`), following behavior is observed:

![image](https://user-images.githubusercontent.com/8092225/44437586-3a320e00-a591-11e8-8df1-c2422598cd84.png)

![image](https://user-images.githubusercontent.com/8092225/44437656-81b89a00-a591-11e8-895e-7619ee4171f1.png)
