### PR TITLE
PR: bug fix for statistics test

### DIFF
--- a/testfiles/shelltests/s3mBigRepositoryTests.sh
+++ b/testfiles/shelltests/s3mBigRepositoryTests.sh
@@ -112,10 +112,10 @@ testLogCorrectness() {
 	assertTrue "[ '$UNSTR_NUM_CONFLICTING_LOC' = '2' ]"
 
 	FP_REDUCTION=$(cat jfstmerge.summary | grep -Eo "A reduction of [0-9]+[.,][0-9]+%" | grep -Eo "[0-9]+[.,][0-9]+%")
-	assertTrue "[ '$FP_REDUCTION' = '100.00%' ]"
+	assertTrue "[ '$FP_REDUCTION' = '100.00%' ] || [ '$FP_REDUCTION' = '100,00%' ]"
 
-	FN_REDUCTION=$(cat jfstmerge.summary | grep -Eo "And a reduction of [0-9]+.[0-9]+%" | grep -Eo "[0-9]+.[0-9]+%")
-	assertTrue "[ '$FN_REDUCTION' = '100.00%' ]"
+	FN_REDUCTION=$(cat jfstmerge.summary | grep -Eo "And a reduction of [0-9]+[.,][0-9]+%" | grep -Eo "[0-9]+[.,][0-9]+%")
+	assertTrue "[ '$FN_REDUCTION' = '100.00%' ] || [ '$FN_REDUCTION' = '100,00%' ]"
 
 	tearDownBig
 }


### PR DESCRIPTION
This pull request attempts to solve issue #44. It address a simple change for the regular expressions of the assertions of testLogCorrectness.