### PR TITLE
PR: automatize binaries creation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,4 +43,19 @@ task copyBinary(type: Copy, dependsOn: assemble, group: "Binaries", description:
     into "${project.getProjectDir()}" + File.separator + "binary"
     rename "jFSTMerge.*", "jFSTMerge.jar"
 }
-build.finalizedBy(copyBinary)
+
+task updateInstaller(type: Copy, dependsOn: assemble, group: "Binaries", description: "Update installer jar.") {
+    String installerPath = "${project.getProjectDir()}" + File.separator + "installer"
+    from fatJar
+    into installerPath
+    rename "jFSTMerge.*", "s3m.jar"
+    
+    doLast {
+        ant.jar(update: "true", destfile: installerPath + File.separator + "s3mInstaller.jar") {
+            zipfileset(file: installerPath + File.separator + "s3m.jar")
+        }
+        
+        delete installerPath + File.separator + "s3m.jar"
+    }
+}
+build.finalizedBy(copyBinary, updateInstaller)

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ repositories {
 dependencies {
     compile fileTree(dir: 'dependencies', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
+    testCompile 'org.assertj:assertj-core:3.11.0'
 }
 
 // the lines bellow deal with exporting a running jar
@@ -19,6 +20,8 @@ jar {
 }
 
 task fatJar(type: Jar) {
+    group 'Binaries'
+
     manifest.from jar.manifest
     classifier = 'all'
     from {
@@ -34,3 +37,10 @@ task fatJar(type: Jar) {
 artifacts {
     archives fatJar
 }
+
+task copyBinary(type: Copy, dependsOn: assemble, group: "Binaries", description: "Copy binaries to /binary folder.") {
+    from fatJar
+    into "${project.getProjectDir()}" + File.separator + "binary"
+    rename "jFSTMerge.*", "jFSTMerge.jar"
+}
+build.finalizedBy(copyBinary)


### PR DESCRIPTION
This PR attempts to solve issue #30. It addresses the following changes:

- Invoking `gradle build` now copies s3m's main binary to `/binary` folder. It's possible to execute this task separately, invoking `gradle copyBinary` (the files will be assembled before copying, but not tested).
- Invoking `gradle build` now updates s3m's installer. Similarly, it's possible to execute this task separately, invoking `gradle updateInstaller`.

These changes are still being iterated on.