### PR TITLE
PR: Cryptography performance test improvement

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+installer/*.jar filter=lfs diff=lfs merge=lfs -text
+binary/*.jar filter=lfs diff=lfs merge=lfs -text

--- a/build.gradle
+++ b/build.gradle
@@ -43,4 +43,19 @@ task copyBinary(type: Copy, dependsOn: assemble, group: "Binaries", description:
     into "${project.getProjectDir()}" + File.separator + "binary"
     rename "jFSTMerge.*", "jFSTMerge.jar"
 }
-build.finalizedBy(copyBinary)
+
+task updateInstaller(type: Copy, dependsOn: assemble, group: "Binaries", description: "Update installer jar.") {
+    String installerPath = "${project.getProjectDir()}" + File.separator + "installer"
+    from fatJar
+    into installerPath
+    rename "jFSTMerge.*", "s3m.jar"
+    
+    doLast {
+        ant.jar(update: "true", destfile: installerPath + File.separator + "s3mInstaller.jar") {
+            zipfileset(file: installerPath + File.separator + "s3m.jar")
+        }
+        
+        delete installerPath + File.separator + "s3m.jar"
+    }
+}
+build.finalizedBy(copyBinary, updateInstaller)

--- a/build.gradle
+++ b/build.gradle
@@ -19,8 +19,7 @@ jar {
     }
 }
 
-task fatJar(type: Jar) {
-    group 'Binaries'
+task fatJar(type: Jar, group: "Binaries", description: "Creates S3M's main binary.") {
 
     manifest.from jar.manifest
     classifier = 'all'
@@ -38,24 +37,23 @@ artifacts {
     archives fatJar
 }
 
-task copyBinary(type: Copy, dependsOn: assemble, group: "Binaries", description: "Copy binaries to /binary folder.") {
+task copyBinary(type: Copy, dependsOn: assemble, group: "Binaries", description: "Copies binaries to /binary folder.") {
     from fatJar
-    into "${project.getProjectDir()}" + File.separator + "binary"
+    into "binary"
     rename "jFSTMerge.*", "jFSTMerge.jar"
 }
 
-task updateInstaller(type: Copy, dependsOn: assemble, group: "Binaries", description: "Update installer jar.") {
-    String installerPath = "${project.getProjectDir()}" + File.separator + "installer"
+task updateInstaller(type: Copy, dependsOn: assemble, group: "Binaries", description: "Updates installer jar.") {
     from fatJar
-    into installerPath
+    into "installer"
     rename "jFSTMerge.*", "s3m.jar"
     
     doLast {
-        ant.jar(update: "true", destfile: installerPath + File.separator + "s3mInstaller.jar") {
-            zipfileset(file: installerPath + File.separator + "s3m.jar")
+        ant.jar(update: "true", destfile: "installer/s3mInstaller.jar") {
+            zipfileset(file: "installer/s3m.jar")
         }
         
-        delete installerPath + File.separator + "s3m.jar"
+        delete "installer/s3m.jar"
     }
 }
 build.finalizedBy(copyBinary, updateInstaller)

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ repositories {
 dependencies {
     compile fileTree(dir: 'dependencies', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
+    testCompile 'org.assertj:assertj-core:3.11.0'
 }
 
 // the lines bellow deal with exporting a running jar
@@ -19,6 +20,8 @@ jar {
 }
 
 task fatJar(type: Jar) {
+    group 'Binaries'
+
     manifest.from jar.manifest
     classifier = 'all'
     from {
@@ -34,3 +37,10 @@ task fatJar(type: Jar) {
 artifacts {
     archives fatJar
 }
+
+task copyBinary(type: Copy, dependsOn: assemble, group: "Binaries", description: "Copy binaries to /binary folder.") {
+    from fatJar
+    into "${project.getProjectDir()}" + File.separator + "binary"
+    rename "jFSTMerge.*", "jFSTMerge.jar"
+}
+build.finalizedBy(copyBinary)

--- a/src/test/java/br/ufpe/cin/performance/CryptoPerformanceTest.java
+++ b/src/test/java/br/ufpe/cin/performance/CryptoPerformanceTest.java
@@ -1,14 +1,10 @@
 package br.ufpe.cin.performance;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.*;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import static java.nio.file.StandardCopyOption.*;
 
 import br.ufpe.cin.crypto.CryptoUtils;
 import br.ufpe.cin.exceptions.CryptoException;
@@ -18,12 +14,11 @@ import br.ufpe.cin.app.JFSTMerge;
 
 public class CryptoPerformanceTest {
 
-	private static final int NUM_TESTS = 5;
-	private static final int NUM_ITERATIONS = 5;
-	private static final double ACCEPTED_MARGIN = 0.3;
+	private static final int NUM_ITERATIONS = 6;
+	private static final double ACCEPTED_MARGIN = 0.4;
 	
 	@BeforeClass
-	public static void setUpBeforeClass() throws Exception {
+	public static void setUpBeforeClass() {
 		//hidding sysout output
 		@SuppressWarnings("unused")
 		PrintStream originalStream = System.out;
@@ -40,43 +35,84 @@ public class CryptoPerformanceTest {
 			decrypt("jfstmerge.files");
 		} catch (CryptoException e) {
 			// The files are already decrypted.
-			System.out.println("Cryptography performance test: the files are already decrypted.");
+			System.out.println("Cryptography performance test: the files are already decrypted. Proceeding normally.");
 		}
-	}
-
-	@After
-	public void encryptFiles() throws CryptoException {
-		encrypt("jfstmerge.statistics");
-		encrypt("jfstmerge.files");
 	}
 		
 	@Test
-	public void testPerformance() throws CryptoException {
+	public void testPerformanceWithDeletion() {
 
 		JFSTMerge.isCryptographed = false;
-		long noCryptoMean = computeMeanTimeOfMergeProcedure(0);
+		long noCryptoMean = computeMeanTimeOfMergeProcedure("testfiles/deletioninnerinleft");
 
 		JFSTMerge.isCryptographed = true;
-		long cryptoMean = computeMeanTimeOfMergeProcedure(0);
+		long cryptoMean = computeMeanTimeOfMergeProcedure("testfiles/deletioninnerinleft");
 
-		assertTrue((double) (cryptoMean - noCryptoMean) <= ACCEPTED_MARGIN * noCryptoMean);
-
+		assertThat((double) (cryptoMean - noCryptoMean)).isLessThanOrEqualTo(ACCEPTED_MARGIN * noCryptoMean);
 	}
 
-	private long computeMeanTimeOfMergeProcedure(int testCase) {
-		long totalTime = 0;
+	@Test
+	public void testPerformanceWithDuplications() {
+
+		JFSTMerge.isCryptographed = false;
+		long noCryptoMean = computeMeanTimeOfMergeProcedure("testfiles/duplicationsconflicting");
+
+		JFSTMerge.isCryptographed = true;
+		long cryptoMean = computeMeanTimeOfMergeProcedure("testfiles/duplicationsconflicting");
+
+		assertThat((double) (cryptoMean - noCryptoMean)).isLessThanOrEqualTo(ACCEPTED_MARGIN * noCryptoMean);
+	}
+
+	@Test
+	public void testPerformanceWithInitializations() {
+
+		JFSTMerge.isCryptographed = false;
+		long noCryptoMean = computeMeanTimeOfMergeProcedure("testfiles/initlblocksnobase");
+
+		JFSTMerge.isCryptographed = true;
+		long cryptoMean = computeMeanTimeOfMergeProcedure("testfiles/initlblocksnobase");
+
+		assertThat((double) (cryptoMean - noCryptoMean)).isLessThanOrEqualTo(ACCEPTED_MARGIN * noCryptoMean);
+	}
+
+	@Test
+	public void testPerformanceWithNewReferencing() {
+
+		JFSTMerge.isCryptographed = false;
+		long noCryptoMean = computeMeanTimeOfMergeProcedure("testfiles/nereomethodfield");
+
+		JFSTMerge.isCryptographed = true;
+		long cryptoMean = computeMeanTimeOfMergeProcedure("testfiles/nereomethodfield");
+
+		assertThat((double) (cryptoMean - noCryptoMean)).isLessThanOrEqualTo(ACCEPTED_MARGIN * noCryptoMean);
+	}
+
+	@Test
+	public void testPerformanceWithRenaming() {
+
+		JFSTMerge.isCryptographed = false;
+		long noCryptoMean = computeMeanTimeOfMergeProcedure("testfiles/renaminginright");
+
+		JFSTMerge.isCryptographed = true;
+		long cryptoMean = computeMeanTimeOfMergeProcedure("testfiles/renaminginright");
+
+		assertThat((double) (cryptoMean - noCryptoMean)).isLessThanOrEqualTo(ACCEPTED_MARGIN * noCryptoMean);
+	}
+
+	private long computeMeanTimeOfMergeProcedure(String testFilesDirectory) {
+		long initialTime, finalTime, totalTime = 0;
+
 		for(int i = 0; i < NUM_ITERATIONS; i++) {
-			long initialTime = System.currentTimeMillis();
 
+			initialTime = System.currentTimeMillis();
 			new JFSTMerge().mergeFiles(
-					new File("testfiles/cryptoperformance/test" + testCase + "/left.java"),
-					new File("testfiles/cryptoperformance/test" + testCase + "/base.java"),
-					new File("testfiles/cryptoperformance/test" + testCase + "/right.java"),
+					new File(testFilesDirectory + "/left/Test.java"),
+					new File(testFilesDirectory + "/base/Test.java"),
+					new File(testFilesDirectory + "/right/Test.java"),
 					null);
+			finalTime = System.currentTimeMillis();
 
-			long finalTime = System.currentTimeMillis();
 			totalTime += finalTime - initialTime;
-
 		}
 
 		return totalTime / NUM_ITERATIONS;
@@ -87,13 +123,6 @@ public class CryptoPerformanceTest {
 
 		File file = new File(logPath);
 		CryptoUtils.decrypt(file, file);
-	}
-
-	private static void encrypt(String fileName) throws CryptoException {
-		String logPath = System.getProperty("user.home") + File.separator + ".jfstmerge" + File.separator + fileName;
-
-		File file = new File(logPath);
-		CryptoUtils.encrypt(file, file);
 	}
 	
 }

--- a/src/test/java/br/ufpe/cin/performance/CryptoPerformanceTest.java
+++ b/src/test/java/br/ufpe/cin/performance/CryptoPerformanceTest.java
@@ -1,4 +1,4 @@
-package test.java.br.ufpe.cin.performance;
+package br.ufpe.cin.performance;
 
 import static org.junit.Assert.assertTrue;
 
@@ -10,27 +10,17 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import static java.nio.file.StandardCopyOption.*;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import br.ufpe.cin.crypto.CryptoUtils;
+import br.ufpe.cin.exceptions.CryptoException;
+import org.junit.*;
 
 import br.ufpe.cin.app.JFSTMerge;
 
 public class CryptoPerformanceTest {
-	
-	private static final int NUM_ITERATIONS = 6;
+
 	private static final int NUM_TESTS = 5;
+	private static final int NUM_ITERATIONS = 5;
 	private static final double ACCEPTED_MARGIN = 0.3;
-	
-	public static File getLogPath(String file) {
-		return new File(System.getProperty("user.home") + File.separator + ".jfstmerge" + File.separator + file);
-	}
-	
-	public static void renameFile(String file1, String file2) throws Exception {
-		File logPath   = getLogPath(file1);
-		File logCopyPath = getLogPath(file2);
-		Files.move(logPath.toPath(), logCopyPath.toPath(), REPLACE_EXISTING);
-	}
 	
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
@@ -41,51 +31,69 @@ public class CryptoPerformanceTest {
 			public void write(int b) {}
 		});
 		System.setOut(hideStream);
-		
-		renameFile("jfstmerge.statistics", "jfstmerge.statistics2");
     }
-	
-	@AfterClass
-	public static void tearDownAfterClass() throws Exception {
-		renameFile("jfstmerge.statistics2", "jfstmerge.statistics");
-	}
-	
-	public long computeMeanTimeOfMergeProcedure(int testCase) {
-		long totalTime = 0;
-		for(int i = 0; i < NUM_ITERATIONS; i++) {
-			long initialTime = System.currentTimeMillis();
-					
-			new JFSTMerge().mergeFiles(
-					new File("testfiles/cryptoperformance/test" + testCase + "/left.java"), 
-					new File("testfiles/cryptoperformance/test" + testCase + "/base.java"), 
-					new File("testfiles/cryptoperformance/test" + testCase + "/right.java"),
-					null);
-			
-			long finalTime = System.currentTimeMillis();
-			totalTime += finalTime - initialTime;
-			
+
+    @Before
+	public void decryptFiles() {
+		try {
+			decrypt("jfstmerge.statistics");
+			decrypt("jfstmerge.files");
+		} catch (CryptoException e) {
+			// The files are already decrypted.
+			System.out.println("Cryptography performance test: the files are already decrypted.");
 		}
-		
-		return totalTime / NUM_ITERATIONS;
+	}
+
+	@After
+	public void encryptFiles() throws CryptoException {
+		encrypt("jfstmerge.statistics");
+		encrypt("jfstmerge.files");
 	}
 		
 	@Test
-	public void testPerformance() throws Exception {
-			
-		for(int i = 0; i < NUM_TESTS; i++) {
-			
-			JFSTMerge.isCryptographed = false;
-			long noCryptoMean = computeMeanTimeOfMergeProcedure(i);	
-		
-			JFSTMerge.isCryptographed = true;
-			long cryptoMean = computeMeanTimeOfMergeProcedure(i);
-			
-			assertTrue((double) (cryptoMean - noCryptoMean) <= ACCEPTED_MARGIN * noCryptoMean);
-			
-			// Renaming statistics file to not block next non-cryptographed merge, simplifying operations.
-			renameFile("jfstmerge.statistics", "jfstmerge.statistics2");
+	public void testPerformance() throws CryptoException {
+
+		JFSTMerge.isCryptographed = false;
+		long noCryptoMean = computeMeanTimeOfMergeProcedure(0);
+
+		JFSTMerge.isCryptographed = true;
+		long cryptoMean = computeMeanTimeOfMergeProcedure(0);
+
+		assertTrue((double) (cryptoMean - noCryptoMean) <= ACCEPTED_MARGIN * noCryptoMean);
+
+	}
+
+	private long computeMeanTimeOfMergeProcedure(int testCase) {
+		long totalTime = 0;
+		for(int i = 0; i < NUM_ITERATIONS; i++) {
+			long initialTime = System.currentTimeMillis();
+
+			new JFSTMerge().mergeFiles(
+					new File("testfiles/cryptoperformance/test" + testCase + "/left.java"),
+					new File("testfiles/cryptoperformance/test" + testCase + "/base.java"),
+					new File("testfiles/cryptoperformance/test" + testCase + "/right.java"),
+					null);
+
+			long finalTime = System.currentTimeMillis();
+			totalTime += finalTime - initialTime;
+
 		}
-		
+
+		return totalTime / NUM_ITERATIONS;
+	}
+
+	private static void decrypt(String fileName) throws CryptoException {
+		String logPath = System.getProperty("user.home") + File.separator + ".jfstmerge" + File.separator + fileName;
+
+		File file = new File(logPath);
+		CryptoUtils.decrypt(file, file);
+	}
+
+	private static void encrypt(String fileName) throws CryptoException {
+		String logPath = System.getProperty("user.home") + File.separator + ".jfstmerge" + File.separator + fileName;
+
+		File file = new File(logPath);
+		CryptoUtils.encrypt(file, file);
 	}
 	
 }

--- a/testfiles/cryptoperformance/test0/base.java
+++ b/testfiles/cryptoperformance/test0/base.java
@@ -1,7 +1,0 @@
-package com.example;
-
-public class Test {
-  class A {
-    double a;
-  }
-}

--- a/testfiles/cryptoperformance/test0/left.java
+++ b/testfiles/cryptoperformance/test0/left.java
@@ -1,5 +1,0 @@
-package com.example;
-
-public class Test {
-	void m(){}
-}

--- a/testfiles/cryptoperformance/test0/right.java
+++ b/testfiles/cryptoperformance/test0/right.java
@@ -1,8 +1,0 @@
-package com.example;
-
-public class Test {
-	class A {
-		double a;
-	}
-	int b;
-}

--- a/testfiles/cryptoperformance/test1/base.java
+++ b/testfiles/cryptoperformance/test1/base.java
@@ -1,7 +1,0 @@
-package com.example;
-
-public class Test {
-  class A {
-    double a;
-  }
-}

--- a/testfiles/cryptoperformance/test1/left.java
+++ b/testfiles/cryptoperformance/test1/left.java
@@ -1,8 +1,0 @@
-package com.example;
-
-public class Test {
-  class B {
-	double a;
-	double b;
-  }
-}

--- a/testfiles/cryptoperformance/test1/right.java
+++ b/testfiles/cryptoperformance/test1/right.java
@@ -1,8 +1,0 @@
-package com.example;
-
-public class Test {
-  int a;
-  class A {
-    double a;
-  }
-}

--- a/testfiles/cryptoperformance/test2/base.java
+++ b/testfiles/cryptoperformance/test2/base.java
@@ -1,7 +1,0 @@
-package com.example;
-
-public class Test {
-  class A {
-    double a;
-  }
-}

--- a/testfiles/cryptoperformance/test2/left.java
+++ b/testfiles/cryptoperformance/test2/left.java
@@ -1,7 +1,0 @@
-package com.example;
-
-public class Test {
-  class B {
-	double a;
-  }
-}

--- a/testfiles/cryptoperformance/test2/right.java
+++ b/testfiles/cryptoperformance/test2/right.java
@@ -1,8 +1,0 @@
-package com.example;
-
-public class Test {
-	class A {
-		double a;
-		double b;
-	}
-}

--- a/testfiles/cryptoperformance/test3/base.java
+++ b/testfiles/cryptoperformance/test3/base.java
@@ -1,8 +1,0 @@
-public class Test {
-	
-	public void m()
-	{
-
-	}
-
-}

--- a/testfiles/cryptoperformance/test3/left.java
+++ b/testfiles/cryptoperformance/test3/left.java
@@ -1,8 +1,0 @@
-public class Test {
-	
-	public void n()
-	{
-
-	}
-
-}

--- a/testfiles/cryptoperformance/test3/right.java
+++ b/testfiles/cryptoperformance/test3/right.java
@@ -1,8 +1,0 @@
-public class Test {
-	
-	public void m()
-	{
-		int a;
-	}
-
-}

--- a/testfiles/cryptoperformance/test4/base.java
+++ b/testfiles/cryptoperformance/test4/base.java
@@ -1,8 +1,0 @@
-public class Test {
-	
-	public void m()
-	{
-
-	}
-
-}

--- a/testfiles/cryptoperformance/test4/left.java
+++ b/testfiles/cryptoperformance/test4/left.java
@@ -1,8 +1,0 @@
-public class Test {
-	
-	public void m()
-	{
-		int a;
-	}
-
-}

--- a/testfiles/cryptoperformance/test4/right.java
+++ b/testfiles/cryptoperformance/test4/right.java
@@ -1,8 +1,0 @@
-public class Test {
-	
-	public void n()
-	{
-
-	}
-
-}


### PR DESCRIPTION
This PR contains changes for the cryptography performance test, making it more generic and overall more reliable.

The most significant change is that the difference between the mean of the elapsed time of a crypto-enabled merge with the one of the crypto-disabled merge has been increased to 40% of the latter from 30%. This shouldn't affect Travis much, but it does affect local tests (since Travis clones the repository each build, while the local repository accumulates data from other merges, increasing cryptography time).

