### PR TITLE
Travis update hotfix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
- - oraclejdk8
+ - openjdk8
 notifications:
  email:
   recipients:


### PR DESCRIPTION
Solves recent failures of Travis by changing jdk to be installed (oraclejdk8 to openjdk8), as detailed [here](https://travis-ci.community/t/install-of-oracle-jdk8-is-failing/4365).