### PR TITLE
Fixes Renaming/Deletion Handlers

### DIFF
--- a/src/main/java/br/ufpe/cin/mergers/handlers/MethodAndConstructorRenamingAndDeletionHandler.java
+++ b/src/main/java/br/ufpe/cin/mergers/handlers/MethodAndConstructorRenamingAndDeletionHandler.java
@@ -38,165 +38,166 @@ import java.util.stream.Collectors;
  * @author Giovanni Barros (gaabs@cin.ufpe.br)
  */
 public final class MethodAndConstructorRenamingAndDeletionHandler implements ConflictHandler {
-    private RenamingHandler renamingHandler;
+	private RenamingHandler renamingHandler;
 
-    public MethodAndConstructorRenamingAndDeletionHandler() {
-        this.renamingHandler = RenamingHandlerFactory.getHandler(JFSTMerge.renamingStrategy);
-    }
+	public MethodAndConstructorRenamingAndDeletionHandler() {
+		this.renamingHandler = RenamingHandlerFactory.getHandler(JFSTMerge.renamingStrategy);
+	}
 
-    @Override
-    public void handle(MergeContext context) throws TextualMergeException {
+	@Override
+	public void handle(MergeContext context) throws TextualMergeException {
 
-        /*
-         * 1. Identification Step: Traverses the base tree looking for renamed or
-         * deleted nodes, filling the renamedWithoutBodyChanges and
-         * deletedOrRenamedWithoutBodyChanges attributes.
-         */
-        identifyRenamingOrDeletionNodes(context);
+		/*
+		 * 1. Identification Step: Traverses the base tree looking for renamed or
+		 * deleted nodes, filling the renamedWithoutBodyChanges and
+		 * deletedOrRenamedWithoutBodyChanges attributes.
+		 */
+		identifyRenamingOrDeletionNodes(context);
 
-        /*
-         * 2. Match Step: For each of the base renamed nodes, we find the nodes from the
-         * left, right and merge trees involved in this renaming. If we can't find the
-         * left or the right node, we treat them as deleted.
-         */
-        List<Quartet<FSTNode, FSTNode, FSTNode, FSTNode>> renamingMatches = retrieveRenamingMatches(context);
+		/*
+		 * 2. Match Step: For each of the base renamed nodes, we find the nodes from the
+		 * left, right and merge trees involved in this renaming. If we can't find the
+		 * left or the right node, we treat them as deleted.
+		 */
+		List<Quartet<FSTNode, FSTNode, FSTNode, FSTNode>> renamingMatches = retrieveRenamingMatches(context);
 
-        /*
-         * 3. Handling Step: For each of the matches, we simply run a decision tree to
-         * decide what do to with them, based on their renaming types.
-         */
-        handle(context, renamingMatches);
+		/*
+		 * 3. Handling Step: For each of the matches, we simply run a decision tree to
+		 * decide what do to with them, based on their renaming types.
+		 */
+		handle(context, renamingMatches);
 
-    }
+	}
 
-    private void identifyRenamingOrDeletionNodes(MergeContext context) {
-        List<FSTTerminal> terminals = Traverser.collectTerminals(context.baseTree);
-        for (FSTTerminal terminal : terminals) {
-            identifyRenamingOrDeletion(Side.LEFT, context, terminal, context.leftTree, context.addedLeftNodes);
-            identifyRenamingOrDeletion(Side.RIGHT, context, terminal, context.rightTree, context.addedRightNodes);
-        }
-    }
+	private void identifyRenamingOrDeletionNodes(MergeContext context) {
+		List<FSTTerminal> terminals = Traverser.collectTerminals(context.baseTree);
+		terminals.stream().filter(terminal -> RenamingUtils.isMethodOrConstructorNode(terminal))
+		.forEach(terminal -> {
+			identifyRenamingOrDeletion(Side.LEFT, context, terminal, context.leftTree, context.addedLeftNodes);
+			identifyRenamingOrDeletion(Side.RIGHT, context, terminal, context.rightTree, context.addedRightNodes);
+		});
+	}
 
-    private void identifyRenamingOrDeletion(Side contribution, MergeContext context, FSTNode node,
-            FSTNode contributionTree, List<FSTNode> addedNodes) {
+	private void identifyRenamingOrDeletion(Side contribution, MergeContext context, FSTNode node,
+			FSTNode contributionTree, List<FSTNode> addedNodes) {
 
-        if (isRenamingWithoutBodyChanges(node, contributionTree, addedNodes)) {
-            context.renamedWithoutBodyChanges.add(Pair.of(contribution, node));
-        }
+		if (isRenamingWithoutBodyChanges(node, contributionTree, addedNodes)) {
+			context.renamedWithoutBodyChanges.add(Pair.of(contribution, node));
+		}
 
-        if (isDeletionOrRenamingWithBodyChanges(node, contributionTree, addedNodes)) {
-            context.deletedOrRenamedWithBodyChanges.add(Pair.of(contribution, node));
-        }
-    }
+		if (isDeletionOrRenamingWithBodyChanges(node, contributionTree, addedNodes)) {
+			context.deletedOrRenamedWithBodyChanges.add(Pair.of(contribution, node));
+		}
+	}
 
-    private boolean isRenamingWithoutBodyChanges(FSTNode node, FSTNode contributionTree, List<FSTNode> addedNodes) {
-        return !isInContribution(node, contributionTree) && matchesWithEqualBody(node, addedNodes);
-    }
+	private boolean isRenamingWithoutBodyChanges(FSTNode node, FSTNode contributionTree, List<FSTNode> addedNodes) {
+		return !isInContribution(node, contributionTree) && matchesWithEqualBody(node, addedNodes);
+	}
 
-    private boolean isDeletionOrRenamingWithBodyChanges(FSTNode node, FSTNode contributionTree,
-            List<FSTNode> addedNodes) {
-        return !isInContribution(node, contributionTree) && !matchesWithEqualBody(node, addedNodes);
-    }
+	private boolean isDeletionOrRenamingWithBodyChanges(FSTNode node, FSTNode contributionTree,
+			List<FSTNode> addedNodes) {
+		return !isInContribution(node, contributionTree) && !matchesWithEqualBody(node, addedNodes);
+	}
 
-    private boolean isInContribution(FSTNode node, FSTNode contributionTree) {
-        return Traverser.isInTree(node, contributionTree);
-    }
+	private boolean isInContribution(FSTNode node, FSTNode contributionTree) {
+		return Traverser.isInTree(node, contributionTree);
+	}
 
-    private boolean matchesWithEqualBody(FSTNode baseNode, List<FSTNode> addedNodes) {
-        return addedNodes.stream().filter(node -> node instanceof FSTTerminal)
-                .anyMatch(node -> RenamingUtils.haveEqualBodyModuloWhitespace(baseNode, node));
-    }
+	private boolean matchesWithEqualBody(FSTNode baseNode, List<FSTNode> addedNodes) {
+		return addedNodes.stream().filter(node -> node instanceof FSTTerminal)
+				.anyMatch(node -> RenamingUtils.haveEqualBodyModuloWhitespace(baseNode, node));
+	}
 
-    private List<Quartet<FSTNode, FSTNode, FSTNode, FSTNode>> retrieveRenamingMatches(MergeContext context) {
-        List<Pair<Side, FSTNode>> renamedNodes = unionRenamedNodes(context.renamedWithoutBodyChanges,
-                context.deletedOrRenamedWithBodyChanges);
-        return renamedNodes.stream().map(pair -> retrieveScenarioNodes(context, pair.getRight()))
-                .filter(triple -> triple.getLeft() != null || triple.getRight() != null)
-                .map(triple -> retrieveScenarioNodesWithMergeNode(context, triple)).distinct()
-                .collect(Collectors.toList());
-    }
+	private List<Quartet<FSTNode, FSTNode, FSTNode, FSTNode>> retrieveRenamingMatches(MergeContext context) {
+		List<Pair<Side, FSTNode>> renamedNodes = unionRenamedNodes(context.renamedWithoutBodyChanges,
+				context.deletedOrRenamedWithBodyChanges);
+		return renamedNodes.stream().map(pair -> retrieveScenarioNodes(context, pair.getRight()))
+				.filter(triple -> triple.getLeft() != null || triple.getRight() != null)
+				.map(triple -> retrieveScenarioNodesWithMergeNode(context, triple)).distinct()
+				.collect(Collectors.toList());
+	}
 
-    private Triple<FSTNode, FSTNode, FSTNode> retrieveScenarioNodes(MergeContext context, FSTNode baseNode) {
-        return Triple.of(getMostAccurateMatch(baseNode, context.leftTree), baseNode,
-                getMostAccurateMatch(baseNode, context.rightTree));
-    }
+	private Triple<FSTNode, FSTNode, FSTNode> retrieveScenarioNodes(MergeContext context, FSTNode baseNode) {
+		return Triple.of(getMostAccurateMatch(baseNode, context.leftTree), baseNode,
+				getMostAccurateMatch(baseNode, context.rightTree));
+	}
 
-    private Quartet<FSTNode, FSTNode, FSTNode, FSTNode> retrieveScenarioNodesWithMergeNode(MergeContext context,
-            Triple<FSTNode, FSTNode, FSTNode> scenarioNodes) {
-        FSTNode leftNode = scenarioNodes.getLeft();
-        FSTNode baseNode = scenarioNodes.getMiddle();
-        FSTNode rightNode = scenarioNodes.getRight();
+	private Quartet<FSTNode, FSTNode, FSTNode, FSTNode> retrieveScenarioNodesWithMergeNode(MergeContext context,
+			Triple<FSTNode, FSTNode, FSTNode> scenarioNodes) {
+		FSTNode leftNode = scenarioNodes.getLeft();
+		FSTNode baseNode = scenarioNodes.getMiddle();
+		FSTNode rightNode = scenarioNodes.getRight();
 
-        if (leftNode != null)
-            return Quartet.with(leftNode, baseNode, rightNode,
-                    getCorrespondentNode(leftNode, context.superImposedTree));
-        else
-            return Quartet.with(leftNode, baseNode, rightNode,
-                    getCorrespondentNode(rightNode, context.superImposedTree));
-    }
+		if (leftNode != null)
+			return Quartet.with(leftNode, baseNode, rightNode,
+					getCorrespondentNode(leftNode, context.superImposedTree));
+		else
+			return Quartet.with(leftNode, baseNode, rightNode,
+					getCorrespondentNode(rightNode, context.superImposedTree));
+	}
 
-    private FSTNode getCorrespondentNode(FSTNode node, FSTNode tree) {
-        return Traverser.retrieveNodeFromTree(node, tree);
-    }
+	private FSTNode getCorrespondentNode(FSTNode node, FSTNode tree) {
+		return Traverser.retrieveNodeFromTree(node, tree);
+	}
 
-    private FSTNode getMostAccurateMatch(FSTNode node, FSTNode contributionTree) {
-        List<FSTTerminal> terminals = Traverser.collectTerminals(contributionTree);
-        if (RenamingUtils.isAbstractMethod(node)) {
-            return getMostAccurateMatchForAbstractMethods(node, terminals);
-        } else {
-            return getMostAccurateMatchForNonAbstractMethods(node, terminals);
-        }
-    }
+	private FSTNode getMostAccurateMatch(FSTNode node, FSTNode contributionTree) {
+		List<FSTTerminal> terminals = Traverser.collectTerminals(contributionTree);
+		if (RenamingUtils.isAbstractMethod(node)) {
+			return getMostAccurateMatchForAbstractMethods(node, terminals);
+		} else {
+			return getMostAccurateMatchForNonAbstractMethods(node, terminals);
+		}
+	}
 
-    private FSTNode getMostAccurateMatchForAbstractMethods(FSTNode node, List<FSTTerminal> terminals) {
-        FSTNode match = tryFindFirstMatch(terminals, node, (n1, n2) -> RenamingUtils.haveEqualSignature(n1, n2));
-        if (match == null) {
-            match = tryFindFirstMatch(terminals, node, (n1, n2) -> RenamingUtils.haveEqualSignatureButName(n1, n2)
-                    || RenamingUtils.haveEqualSignatureButArguments(n1, n2));
-        }
-        return match;
-    }
+	private FSTNode getMostAccurateMatchForAbstractMethods(FSTNode node, List<FSTTerminal> terminals) {
+		FSTNode match = tryFindFirstMatch(terminals, node, (n1, n2) -> RenamingUtils.haveEqualSignature(n1, n2));
+		if (match == null) {
+			match = tryFindFirstMatch(terminals, node, (n1, n2) -> RenamingUtils.haveEqualSignatureButName(n1, n2)
+					|| RenamingUtils.haveEqualSignatureButArguments(n1, n2));
+		}
+		return match;
+	}
 
-    private FSTNode getMostAccurateMatchForNonAbstractMethods(FSTNode node, List<FSTTerminal> terminals) {
-        FSTNode match = tryFindFirstMatch(terminals, node, (n1, n2) -> RenamingUtils.haveEqualSignature(n1, n2));
-        if (match == null) {
-            match = tryFindFirstMatch(terminals, node, (n1, n2) -> RenamingUtils.haveEqualBodyModuloWhitespace(n1, n2));
-        }
-        if (match == null) {
-            match = tryFindFirstMatch(terminals, node,
-                    (n1, n2) -> RenamingUtils.haveSimilarBodyModuloWhitespace(n1, n2)
-                            && (RenamingUtils.haveEqualSignatureButName(n1, n2)
-                                    || RenamingUtils.haveEqualSignatureButArguments(n1, n2)));
-        }
-        if (match == null) {
-            match = tryFindFirstMatch(terminals, node,
-                    (n1, n2) -> RenamingUtils.oneContainsTheBodyFromTheOther(n1, n2));
-        }
-        return match;
-    }
+	private FSTNode getMostAccurateMatchForNonAbstractMethods(FSTNode node, List<FSTTerminal> terminals) {
+		FSTNode match = tryFindFirstMatch(terminals, node, (n1, n2) -> RenamingUtils.haveEqualSignature(n1, n2));
+		if (match == null) {
+			match = tryFindFirstMatch(terminals, node, (n1, n2) -> RenamingUtils.haveEqualBodyModuloWhitespace(n1, n2));
+		}
+		if (match == null) {
+			match = tryFindFirstMatch(terminals, node,
+					(n1, n2) -> RenamingUtils.haveSimilarBodyModuloWhitespace(n1, n2)
+					&& (RenamingUtils.haveEqualSignatureButName(n1, n2)
+							|| RenamingUtils.haveEqualSignatureButArguments(n1, n2)));
+		}
+		if (match == null) {
+			match = tryFindFirstMatch(terminals, node,
+					(n1, n2) -> RenamingUtils.oneContainsTheBodyFromTheOther(n1, n2));
+		}
+		return match;
+	}
 
-    private FSTNode tryFindFirstMatch(List<FSTTerminal> candidates, FSTNode node,
-            BiPredicate<FSTNode, FSTNode> predicate) {
-        for (FSTNode candidate : candidates) {
-            if (RenamingUtils.isMethodOrConstructorNode(candidate) && predicate.test(node, candidate)) {
-                return candidate;
-            }
-        }
-        return null;
-    }
+	private FSTNode tryFindFirstMatch(List<FSTTerminal> candidates, FSTNode node,
+			BiPredicate<FSTNode, FSTNode> predicate) {
+		for (FSTNode candidate : candidates) {
+			if (RenamingUtils.isMethodOrConstructorNode(candidate) && predicate.test(node, candidate)) {
+				return candidate;
+			}
+		}
+		return null;
+	}
 
-    private List<Pair<Side, FSTNode>> unionRenamedNodes(List<Pair<Side, FSTNode>> renamedWithoutBodyChanges,
-            List<Pair<Side, FSTNode>> deletedOrRenamedWithBodyChanges) {
-        List<Pair<Side, FSTNode>> unionNodes = new ArrayList<>();
-        renamedWithoutBodyChanges.stream().forEach(pair -> unionNodes.add(pair));
-        deletedOrRenamedWithBodyChanges.stream().forEach(pair -> unionNodes.add(pair));
-        return unionNodes;
-    }
+	private List<Pair<Side, FSTNode>> unionRenamedNodes(List<Pair<Side, FSTNode>> renamedWithoutBodyChanges,
+			List<Pair<Side, FSTNode>> deletedOrRenamedWithBodyChanges) {
+		List<Pair<Side, FSTNode>> unionNodes = new ArrayList<>();
+		renamedWithoutBodyChanges.stream().forEach(pair -> unionNodes.add(pair));
+		deletedOrRenamedWithBodyChanges.stream().forEach(pair -> unionNodes.add(pair));
+		return unionNodes;
+	}
 
-    private void handle(MergeContext context, List<Quartet<FSTNode, FSTNode, FSTNode, FSTNode>> renamingMatches)
-            throws TextualMergeException {
-        for (Quartet<FSTNode, FSTNode, FSTNode, FSTNode> match : renamingMatches)
-            renamingHandler.handle(context, match);
-    }
+	private void handle(MergeContext context, List<Quartet<FSTNode, FSTNode, FSTNode, FSTNode>> renamingMatches)
+			throws TextualMergeException {
+		for (Quartet<FSTNode, FSTNode, FSTNode, FSTNode> match : renamingMatches)
+			renamingHandler.handle(context, match);
+	}
 
 }

--- a/src/main/java/br/ufpe/cin/mergers/util/RenamingUtils.java
+++ b/src/main/java/br/ufpe/cin/mergers/util/RenamingUtils.java
@@ -72,12 +72,16 @@ public class RenamingUtils {
         return methodSource.contains("{");
     }
 
-    public static String getMethodBodyWithoutWhitespaces(FSTNode node) {
-        if (isMethodOrConstructorNode(node))
-            return StringUtils.deleteWhitespace(((FSTTerminal) node).getDeclarationBody());
-
-        return StringUtils.EMPTY;
-    }
+	public static String getMethodBodyWithoutWhitespaces(FSTNode node) {
+		if (isMethodOrConstructorNode(node)) {
+			String methodBody = StringUtils.deleteWhitespace(((FSTTerminal) node).getDeclarationBody());
+			if(methodBody.equals(";")) {
+				return StringUtils.EMPTY;
+			}
+				return methodBody;
+		}
+		return StringUtils.EMPTY;
+	}
 
     public static String removeSignature(String string) {
         if (!hasDefinedBody(string))

--- a/src/main/java/br/ufpe/cin/mergers/util/RenamingUtils.java
+++ b/src/main/java/br/ufpe/cin/mergers/util/RenamingUtils.java
@@ -17,295 +17,296 @@ import de.ovgu.cide.fstgen.ast.FSTNode;
 import de.ovgu.cide.fstgen.ast.FSTTerminal;
 
 public class RenamingUtils {
-    public static boolean hasUnstructuredMergeConflict(MergeContext context, String baseContent) {
-        String signature = getTrimmedSignature(baseContent);
+	public static boolean hasUnstructuredMergeConflict(MergeContext context, String baseContent) {
+		String signature = getTrimmedSignature(baseContent);
 
-        return FilesManager.extractMergeConflicts(context.unstructuredOutput).stream()
-                .map(conflict -> FilesManager.getStringContentIntoSingleLineNoSpacing(conflict.toString()))
-                .anyMatch(conflict -> conflict.contains(signature));
-    }
+		return FilesManager.extractMergeConflicts(context.unstructuredOutput).stream()
+				.map(conflict -> FilesManager.getStringContentIntoSingleLineNoSpacing(conflict.toString()))
+				.anyMatch(conflict -> conflict.contains(signature));
+	}
 
-    public static String getMostSimilarNodeContent(String baseContent, FSTNode currentNode, List<FSTNode> addedNodes) {
-        List<Pair<Double, String>> similarNodes = getSimilarNodes(baseContent, currentNode, addedNodes);
+	public static String getMostSimilarNodeContent(String baseContent, FSTNode currentNode, List<FSTNode> addedNodes) {
+		List<Pair<Double, String>> similarNodes = getSimilarNodes(baseContent, currentNode, addedNodes);
 
-        return getMostSimilarContent(similarNodes);
-    }
+		return getMostSimilarContent(similarNodes);
+	}
 
-    public static List<Pair<Double, String>> getSimilarNodes(String baseContent, FSTNode currentNode,
-            List<FSTNode> addedNodes) {
-        // list of possible nodes renaming a previous one
-        List<Pair<Double, String>> similarNodes = new ArrayList<>();
+	public static List<Pair<Double, String>> getSimilarNodes(String baseContent, FSTNode currentNode,
+			List<FSTNode> addedNodes) {
+		// list of possible nodes renaming a previous one
+		List<Pair<Double, String>> similarNodes = new ArrayList<>();
 
-        // 1. getting similar nodes to fulfill renaming conflicts
-        for (FSTNode newNode : addedNodes) { // a possible renamed node is seem as "new" node due to superimposition
-            if (!isMethodOrConstructorNode(newNode))
-                continue;
-            if (!haveSameParent(newNode, currentNode))
-                continue;
+		// 1. getting similar nodes to fulfill renaming conflicts
+		for (FSTNode newNode : addedNodes) { // a possible renamed node is seem as "new" node due to superimposition
+			if (!isMethodOrConstructorNode(newNode))
+				continue;
+			if (!haveSameParent(newNode, currentNode))
+				continue;
 
-            String possibleRenamingContent = ((FSTTerminal) newNode).getBody();
-            double bodySimilarity = FilesManager.computeStringSimilarity(baseContent, possibleRenamingContent);
-            if (bodySimilarity >= JFSTMerge.RENAMING_SIMILARITY_THRESHOLD) {
-                Pair<Double, String> tp = Pair.of(bodySimilarity, possibleRenamingContent);
-                similarNodes.add(tp);
-            }
-        }
+			String possibleRenamingContent = ((FSTTerminal) newNode).getBody();
+			double bodySimilarity = FilesManager.computeStringSimilarity(baseContent, possibleRenamingContent);
+			if (bodySimilarity >= JFSTMerge.RENAMING_SIMILARITY_THRESHOLD) {
+				Pair<Double, String> tp = Pair.of(bodySimilarity, possibleRenamingContent);
+				similarNodes.add(tp);
+			}
+		}
 
-        return similarNodes;
-    }
+		return similarNodes;
+	}
 
-    public static String getMostSimilarContent(List<Pair<Double, String>> similarNodes) {
-        return similarNodes.stream().max(Comparator.comparing(Pair::getLeft)).map(Pair::getRight)
-                .orElse(StringUtils.EMPTY);
-    }
+	public static String getMostSimilarContent(List<Pair<Double, String>> similarNodes) {
+		return similarNodes.stream().max(Comparator.comparing(Pair::getLeft)).map(Pair::getRight)
+				.orElse(StringUtils.EMPTY);
+	}
 
-    public static String getTrimmedSignature(String source) {
-        String trimmedSource = FilesManager.getStringContentIntoSingleLineNoSpacing(source);
-        return getSignature(trimmedSource);
-    }
+	public static String getTrimmedSignature(String source) {
+		String trimmedSource = FilesManager.getStringContentIntoSingleLineNoSpacing(source);
+		return getSignature(trimmedSource);
+	}
 
-    public static String getSignature(String source) {
-        return source.substring(0, hasDefinedBody(source) ? source.indexOf("{") : source.indexOf(";"));
-    }
+	public static String getSignature(String source) {
+		return source.substring(0, hasDefinedBody(source) ? source.indexOf("{") : source.indexOf(";"));
+	}
 
-    public static boolean hasDefinedBody(String methodSource) {
-        return methodSource.contains("{");
-    }
+	public static boolean hasDefinedBody(String methodSource) {
+		return methodSource.contains("{");
+	}
 
 	public static String getMethodBodyWithoutWhitespaces(FSTNode node) {
 		if (isMethodOrConstructorNode(node)) {
-			String methodBody = StringUtils.deleteWhitespace(((FSTTerminal) node).getDeclarationBody());
-			if(methodBody.equals(";")) {
-				return StringUtils.EMPTY;
-			}
+			if(!isAbstractMethod(node)) {
+				String methodBody = StringUtils.deleteWhitespace(((FSTTerminal) node).getDeclarationBody());
 				return methodBody;
+			}
 		}
 		return StringUtils.EMPTY;
 	}
 
-    public static String removeSignature(String string) {
-        if (!hasDefinedBody(string))
-            return StringUtils.EMPTY;
+	public static String removeSignature(String string) {
+		if (!hasDefinedBody(string))
+			return StringUtils.EMPTY;
 
-        return string.replaceFirst("^.[^{]*(?=(\\{))", "");
-    }
+		return string.replaceFirst("^.[^{]*(?=(\\{))", "");
+	}
 
-    public static boolean nodeHasConflict(FSTNode node) {
-        if (isMethodOrConstructorNode(node)) {
-            String body = ((FSTTerminal) node).getBody();
-            return body.contains("<<<<<<< MINE");
-        }
+	public static boolean nodeHasConflict(FSTNode node) {
+		if (isMethodOrConstructorNode(node)) {
+			String body = ((FSTTerminal) node).getBody();
+			return body.contains("<<<<<<< MINE");
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    public static boolean isMethodOrConstructorNode(FSTNode node) {
-        return isMethod(node) || isConstructor(node);
-    }
+	public static boolean isMethodOrConstructorNode(FSTNode node) {
+		return isMethod(node) || isConstructor(node);
+	}
 
-    private static boolean isMethod(FSTNode node) {
-        return node instanceof FSTTerminal && node.getType().equals("MethodDecl");
-    }
+	private static boolean isMethod(FSTNode node) {
+		return node instanceof FSTTerminal && node.getType().equals("MethodDecl");
+	}
 
-    private static boolean isConstructor(FSTNode node) {
-        return node instanceof FSTTerminal && node.getType().equals("ConstructorDecl");
-    }
+	private static boolean isConstructor(FSTNode node) {
+		return node instanceof FSTTerminal && node.getType().equals("ConstructorDecl");
+	}
 
-    public static boolean haveSameParent(FSTNode left, FSTNode right) {
-        return left.getParent().equals(right.getParent());
-    }
+	public static boolean haveSameParent(FSTNode left, FSTNode right) {
+		return left.getParent().equals(right.getParent());
+	}
 
-    public static void generateMutualRenamingConflict(MergeContext context, FSTNode leftNode, FSTNode baseNode,
-            FSTNode rightNode, FSTNode mergeNode, String conflictMessage) {
-        MergeConflict conflict = new MergeConflict(leftNode, baseNode, rightNode, conflictMessage);
-        ((FSTTerminal) mergeNode).setBody(conflict.toString());
+	public static void generateMutualRenamingConflict(MergeContext context, FSTNode leftNode, FSTNode baseNode,
+			FSTNode rightNode, FSTNode mergeNode, String conflictMessage) {
+		MergeConflict conflict = new MergeConflict(leftNode, baseNode, rightNode, conflictMessage);
+		((FSTTerminal) mergeNode).setBody(conflict.toString());
 
-        context.renamingConflicts++;
-        removeUnmmatchedNode(context.superImposedTree, leftNode, rightNode, mergeNode);
-    }
+		context.renamingConflicts++;
+		removeUnmmatchedNode(context.superImposedTree, leftNode, rightNode, mergeNode);
+	}
 
-    public static void removeUnmmatchedNode(FSTNode mergeTree, FSTNode leftNode, FSTNode rightNode, FSTNode mergeNode) {
-        if (equalIfExists(leftNode, mergeNode) && !equalIfExists(rightNode, leftNode))
-            Traverser.removeNode(rightNode, mergeTree);
-    }
+	public static void removeUnmmatchedNode(FSTNode mergeTree, FSTNode leftNode, FSTNode rightNode, FSTNode mergeNode) {
+		if (equalIfExists(leftNode, mergeNode) && !equalIfExists(rightNode, leftNode))
+			Traverser.removeNode(rightNode, mergeTree);
+	}
 
-    private static boolean equalIfExists(FSTNode node1, FSTNode node2) {
-        return node1 != null && node1.equals(node2);
-    }
+	private static boolean equalIfExists(FSTNode node1, FSTNode node2) {
+		return node1 != null && node1.equals(node2);
+	}
 
-    public static String getMergeConflictContentOfOppositeSide(MergeConflict mergeConflict, Side side) {
-        if (side == Side.LEFT)
-            return mergeConflict.getRight();
-        if (side == Side.RIGHT)
-            return mergeConflict.getLeft();
+	public static String getMergeConflictContentOfOppositeSide(MergeConflict mergeConflict, Side side) {
+		if (side == Side.LEFT)
+			return mergeConflict.getRight();
+		if (side == Side.RIGHT)
+			return mergeConflict.getLeft();
 
-        return null;
-    }
+		return null;
+	}
 
-    public static void generateRenamingConflict(MergeContext context, String currentNodeContent, String firstContent,
-            String secondContent, boolean isLeftToRight) {
-        if (!isLeftToRight) {// managing the origin of the changes in the conflict
-            String aux = secondContent;
-            secondContent = firstContent;
-            firstContent = aux;
-        }
+	public static void generateRenamingConflict(MergeContext context, String currentNodeContent, String firstContent,
+			String secondContent, boolean isLeftToRight) {
+		if (!isLeftToRight) {// managing the origin of the changes in the conflict
+			String aux = secondContent;
+			secondContent = firstContent;
+			firstContent = aux;
+		}
 
-        // statistics
-        if (firstContent.isEmpty() || secondContent.isEmpty()) {
-            context.deletionConflicts++;
-        } else {
-            context.renamingConflicts++;
-        }
+		// statistics
+		if (firstContent.isEmpty() || secondContent.isEmpty()) {
+			context.deletionConflicts++;
+		} else {
+			context.renamingConflicts++;
+		}
 
-        // first creates a conflict
-        MergeConflict newConflict = new MergeConflict(firstContent, "", secondContent, "");
-        // second put the conflict in one of the nodes containing the previous conflict,
-        // and deletes the other node containing the possible renamed version
-        FilesManager.findAndReplaceASTNodeContent(context.superImposedTree, currentNodeContent, newConflict.toString());
-        if (isLeftToRight) {
-            FilesManager.findAndDeleteASTNode(context.superImposedTree, firstContent);
-        } else {
-            FilesManager.findAndDeleteASTNode(context.superImposedTree, secondContent);
+		// first creates a conflict
+		MergeConflict newConflict = new MergeConflict(firstContent, "", secondContent, "");
+		// second put the conflict in one of the nodes containing the previous conflict,
+		// and deletes the other node containing the possible renamed version
+		FilesManager.findAndReplaceASTNodeContent(context.superImposedTree, currentNodeContent, newConflict.toString());
+		if (isLeftToRight) {
+			FilesManager.findAndDeleteASTNode(context.superImposedTree, firstContent);
+		} else {
+			FilesManager.findAndDeleteASTNode(context.superImposedTree, secondContent);
 
-        }
-    }
+		}
+	}
 
-    public static List<FSTNode> getMethodsOrConstructors(List<FSTNode> nodes) {
-        return nodes.stream().filter(RenamingUtils::isMethodOrConstructorNode).collect(Collectors.toList());
-    }
+	public static List<FSTNode> getMethodsOrConstructors(List<FSTNode> nodes) {
+		return nodes.stream().filter(RenamingUtils::isMethodOrConstructorNode).collect(Collectors.toList());
+	}
 
-    public static boolean haveDifferentSignature(FSTNode left, FSTNode right) {
-        return !haveEqualSignature(left, right);
-    }
+	public static boolean haveDifferentSignature(FSTNode left, FSTNode right) {
+		return !haveEqualSignature(left, right);
+	}
 
-    public static boolean haveEqualSignature(FSTNode left, FSTNode right) {
-        return left != null && right != null && left.getName().equals(right.getName());
-    }
+	public static boolean haveEqualSignature(FSTNode left, FSTNode right) {
+		return left != null && right != null && left.getName().equals(right.getName());
+	}
 
-    public static boolean haveEqualSignatureButName(FSTNode left, FSTNode right) {
-        assert (!getMethodName(left).equals(getMethodName(right)));
+	public static boolean haveEqualSignatureButName(FSTNode left, FSTNode right) {
+		assert (!getMethodName(left).equals(getMethodName(right)));
 
-        String[] leftArgumentTypes = getMethodArgumentTypes(left);
-        String[] rightArgumentTypes = getMethodArgumentTypes(right);
+		String[] leftArgumentTypes = getMethodArgumentTypes(left);
+		String[] rightArgumentTypes = getMethodArgumentTypes(right);
 
-        return Arrays.equals(leftArgumentTypes, rightArgumentTypes);
-    }
+		return Arrays.equals(leftArgumentTypes, rightArgumentTypes);
+	}
 
-    public static boolean haveEqualSignatureButArguments(FSTNode left, FSTNode right) {
-        assert (!Arrays.equals(getMethodArgumentTypes(left), getMethodArgumentTypes(right)));
+	public static boolean haveEqualSignatureButArguments(FSTNode left, FSTNode right) {
+		assert (!Arrays.equals(getMethodArgumentTypes(left), getMethodArgumentTypes(right)));
 
-        String leftName = getMethodName(left);
-        String rightName = getMethodName(right);
+		String leftName = getMethodName(left);
+		String rightName = getMethodName(right);
 
-        return leftName.equals(rightName);
-    }
+		return leftName.equals(rightName);
+	}
 
-    private static String getMethodName(FSTNode node) {
-        // The signature is stored in a FSTNode has the format
-        // 'name(arg1-arg1-arg2-arg2-arg3-arg3...)'.
-        String[] nodeNameAndArguments = node.getName().split("[()]");
-        return nodeNameAndArguments[0];
-    }
+	private static String getMethodName(FSTNode node) {
+		// The signature is stored in a FSTNode has the format
+		// 'name(arg1-arg1-arg2-arg2-arg3-arg3...)'.
+		String[] nodeNameAndArguments = node.getName().split("[()]");
+		return nodeNameAndArguments[0];
+	}
 
-    private static String[] getMethodArgumentTypes(FSTNode node) {
-        // The signature is stored in a FSTNode has the format
-        // 'name(arg1-arg1-arg2-arg2-arg3-arg3...)'.
-        String[] nodeNameAndArguments = node.getName().split("[()]");
+	private static String[] getMethodArgumentTypes(FSTNode node) {
+		// The signature is stored in a FSTNode has the format
+		// 'name(arg1-arg1-arg2-arg2-arg3-arg3...)'.
+		String[] nodeNameAndArguments = node.getName().split("[()]");
 
-        String[] arguments = nodeNameAndArguments[1].split("-");
-        return arguments;
-    }
+		String[] arguments = nodeNameAndArguments[1].split("-");
+		return arguments;
+	}
 
-    public static boolean oneContainsTheBodyFromTheOther(FSTNode left, FSTNode right) {
-        String leftBody = RenamingUtils.getMethodBodyWithoutWhitespaces(left);
-        String rightBody = RenamingUtils.getMethodBodyWithoutWhitespaces(right);
+	public static boolean oneContainsTheBodyFromTheOther(FSTNode left, FSTNode right) {
+		String leftBody = RenamingUtils.getMethodBodyWithoutWhitespaces(left);
+		String rightBody = RenamingUtils.getMethodBodyWithoutWhitespaces(right);
 
-        return leftBody != StringUtils.EMPTY && rightBody != StringUtils.EMPTY
-                && (leftBody.contains(rightBody) || rightBody.contains(leftBody));
-    }
+		return leftBody != StringUtils.EMPTY && rightBody != StringUtils.EMPTY
+				&& (leftBody.contains(rightBody) || rightBody.contains(leftBody));
+	}
 
-    public static boolean haveDifferentBody(FSTNode left, FSTNode right) {
-        return !haveEqualBodyModuloWhitespace(left, right);
-    }
+	public static boolean haveDifferentBody(FSTNode left, FSTNode right) {
+		return !haveEqualBodyModuloWhitespace(left, right);
+	}
 
-    public static boolean haveEqualBodyModuloWhitespace(FSTNode left, FSTNode right) {
-        String leftBody = RenamingUtils.getMethodBodyWithoutWhitespaces(left);
-        String rightBody = RenamingUtils.getMethodBodyWithoutWhitespaces(right);
+	public static boolean haveEqualBodyModuloWhitespace(FSTNode left, FSTNode right) {
+		String leftBody = RenamingUtils.getMethodBodyWithoutWhitespaces(left);
+		String rightBody = RenamingUtils.getMethodBodyWithoutWhitespaces(right);
 
-        return leftBody.equals(rightBody);
-    }
+		return leftBody.equals(rightBody);
+	}
 
-    public static boolean haveSimilarBodyModuloWhitespace(FSTNode left, FSTNode right) {
-        String leftBody = RenamingUtils.getMethodBodyWithoutWhitespaces(left);
-        String rightBody = RenamingUtils.getMethodBodyWithoutWhitespaces(right);
+	public static boolean haveSimilarBodyModuloWhitespace(FSTNode left, FSTNode right) {
+		String leftBody = RenamingUtils.getMethodBodyWithoutWhitespaces(left);
+		String rightBody = RenamingUtils.getMethodBodyWithoutWhitespaces(right);
 
-        double bodySimilarity = FilesManager.computeStringSimilarity(leftBody, rightBody);
+		double bodySimilarity = FilesManager.computeStringSimilarity(leftBody, rightBody);
 
-        return bodySimilarity >= JFSTMerge.RENAMING_SIMILARITY_THRESHOLD;
-    }
+		return bodySimilarity >= JFSTMerge.RENAMING_SIMILARITY_THRESHOLD;
+	}
 
-    public static void runTextualMerge(MergeContext context, FSTNode leftNode, FSTNode baseNode, FSTNode rightNode,
-            FSTNode mergeNode) throws TextualMergeException {
-        ((FSTTerminal) mergeNode).setBody(mergeContent(leftNode, baseNode, rightNode));
-        ((FSTTerminal) mergeNode).setSpecialTokenPrefix(mergePrefix(leftNode, baseNode, rightNode));
+	public static void runTextualMerge(MergeContext context, FSTNode leftNode, FSTNode baseNode, FSTNode rightNode,
+			FSTNode mergeNode) throws TextualMergeException {
+		((FSTTerminal) mergeNode).setBody(mergeContent(leftNode, baseNode, rightNode));
+		((FSTTerminal) mergeNode).setSpecialTokenPrefix(mergePrefix(leftNode, baseNode, rightNode));
 
-        if (nodeHasConflict(mergeNode))
-            context.renamingConflicts++;
+		if (nodeHasConflict(mergeNode))
+			context.renamingConflicts++;
 
-        removeUnmmatchedNode(context.superImposedTree, leftNode, rightNode, mergeNode);
-    }
+		removeUnmmatchedNode(context.superImposedTree, leftNode, rightNode, mergeNode);
+	}
 
-    private static String mergeContent(FSTNode leftNode, FSTNode baseNode, FSTNode rightNode)
-            throws TextualMergeException {
-        return TextualMerge.merge(getNodeContent(leftNode), getNodeContent(baseNode), getNodeContent(rightNode),
-                JFSTMerge.isWhitespaceIgnored);
-    }
+	private static String mergeContent(FSTNode leftNode, FSTNode baseNode, FSTNode rightNode)
+			throws TextualMergeException {
+		return TextualMerge.merge(getNodeContent(leftNode), getNodeContent(baseNode), getNodeContent(rightNode),
+				JFSTMerge.isWhitespaceIgnored);
+	}
 
-    private static String mergePrefix(FSTNode leftNode, FSTNode baseNode, FSTNode rightNode)
-            throws TextualMergeException {
-        String leftPrefix = getNodePrefix(leftNode);
-        String basePrefix = getNodePrefix(baseNode);
-        String rightPrefix = getNodePrefix(rightNode);
-        return compareAndMerge(leftPrefix, basePrefix, rightPrefix);
-    }
+	private static String mergePrefix(FSTNode leftNode, FSTNode baseNode, FSTNode rightNode)
+			throws TextualMergeException {
+		String leftPrefix = getNodePrefix(leftNode);
+		String basePrefix = getNodePrefix(baseNode);
+		String rightPrefix = getNodePrefix(rightNode);
+		return compareAndMerge(leftPrefix, basePrefix, rightPrefix);
+	}
 
-    public static String compareAndMerge(String left, String base, String right) throws TextualMergeException {
-        String leftTrimmed = left.trim();
-        String baseTrimmed = base.trim();
-        String rightTrimmed = right.trim();
+	public static String compareAndMerge(String left, String base, String right) throws TextualMergeException {
+		String leftTrimmed = left.trim();
+		String baseTrimmed = base.trim();
+		String rightTrimmed = right.trim();
 
-        if (JFSTMerge.isWhitespaceIgnored) {
-            if (base.equals(left) && !base.equals(right)) {
-                return right;
-            } else if (base.equals(right) && !base.equals(left)) {
-                return left;
-            } else if (baseTrimmed.equals(leftTrimmed) && !baseTrimmed.equals(rightTrimmed)) {
-                return right;
-            } else if (baseTrimmed.equals(rightTrimmed) && !baseTrimmed.equals(leftTrimmed)) {
-                return left;
-            } else if (leftTrimmed.equals(rightTrimmed)) {
-                return (left.length() < right.length()) ? left : right;
-            }
-        }
+		if (JFSTMerge.isWhitespaceIgnored) {
+			if (base.equals(left) && !base.equals(right)) {
+				return right;
+			} else if (base.equals(right) && !base.equals(left)) {
+				return left;
+			} else if (baseTrimmed.equals(leftTrimmed) && !baseTrimmed.equals(rightTrimmed)) {
+				return right;
+			} else if (baseTrimmed.equals(rightTrimmed) && !baseTrimmed.equals(leftTrimmed)) {
+				return left;
+			} else if (leftTrimmed.equals(rightTrimmed)) {
+				return (left.length() < right.length()) ? left : right;
+			}
+		}
 
-        return TextualMerge.merge(left, base, right, JFSTMerge.isWhitespaceIgnored);
-    }
+		return TextualMerge.merge(left, base, right, JFSTMerge.isWhitespaceIgnored);
+	}
 
-    public static String getNodeContent(FSTNode node) {
-        if (node == null)
-            return "";
-        return ((FSTTerminal) node).getBody();
-    }
+	public static String getNodeContent(FSTNode node) {
+		if (node == null)
+			return "";
+		return ((FSTTerminal) node).getBody();
+	}
 
-    private static String getNodePrefix(FSTNode node) {
-        if (node == null)
-            return "";
-        return ((FSTTerminal) node).getSpecialTokenPrefix();
-    }
+	private static String getNodePrefix(FSTNode node) {
+		if (node == null)
+			return "";
+		return ((FSTTerminal) node).getSpecialTokenPrefix();
+	}
 
-    public static boolean isAbstractMethod(FSTNode node) {
-        String methodBody = getMethodBodyWithoutWhitespaces(node);
-        return getNodeContent(node).contains("abstract")
-                && (methodBody.equals(";") || methodBody.equals(StringUtils.EMPTY));
-    }
+	public static boolean isAbstractMethod(FSTNode node) {
+		if(isMethodOrConstructorNode(node)) {
+			String methodBody = StringUtils.deleteWhitespace(((FSTTerminal) node).getDeclarationBody());
+			return methodBody.equals(";");
+		}
+		return false;
+	}
 }

--- a/src/test/java/br/ufpe/cin/mergers/handlers/renaming/NoExtraFalsePositivesRenamingHandlerTest.java
+++ b/src/test/java/br/ufpe/cin/mergers/handlers/renaming/NoExtraFalsePositivesRenamingHandlerTest.java
@@ -105,5 +105,19 @@ public class NoExtraFalsePositivesRenamingHandlerTest {
 		assertTrue(ctx.renamingConflicts == 1);
 	}
 	
+	
+	@Test
+	public void testRenamingMatchingOnlyMethodDecls() {
+		MergeContext ctx = 	new JFSTMerge().mergeFiles(
+				new File("testfiles/renamingmatchingonlymethoddecls/left.java"), 
+				new File("testfiles/renamingmatchingonlymethoddecls/base.java"), 
+				new File("testfiles/renamingmatchingonlymethoddecls/right.java"),
+				null);
+		String mergeResult = FilesManager.getStringContentIntoSingleLineNoSpacing(ctx.semistructuredOutput);
+		
+		assertTrue(mergeResult.equals("importjava.util.List;importjavax.inject.Inject;publicinterfaceTest{publicList<Object>ripf(Longl);}"));
+		assertTrue(ctx.renamingConflicts == 0);
+		assertTrue(ctx.deletionConflicts == 0);
+	}
 
 }

--- a/src/test/java/br/ufpe/cin/mergers/handlers/renaming/NoExtraFalsePositivesRenamingHandlerTest.java
+++ b/src/test/java/br/ufpe/cin/mergers/handlers/renaming/NoExtraFalsePositivesRenamingHandlerTest.java
@@ -119,5 +119,19 @@ public class NoExtraFalsePositivesRenamingHandlerTest {
 		assertTrue(ctx.renamingConflicts == 0);
 		assertTrue(ctx.deletionConflicts == 0);
 	}
+	
+	@Test
+	public void testRenamingProperBodyOfAbstractMethods() {
+		MergeContext ctx = 	new JFSTMerge().mergeFiles(
+				new File("testfiles/renamingproperbodyofabstractmethods/left.java"), 
+				new File("testfiles/renamingproperbodyofabstractmethods/base.java"), 
+				new File("testfiles/renamingproperbodyofabstractmethods/right.java"),
+				null);
+		String mergeResult = FilesManager.getStringContentIntoSingleLineNoSpacing(ctx.semistructuredOutput);
+		
+		assertTrue(mergeResult.contains("<<<<<<<MINEpublicObjectm(Objecte){inta;intb;intc;returne;}=======>>>>>>>YOURS"));
+		assertTrue(ctx.renamingConflicts == 0);
+		assertTrue(ctx.deletionConflicts == 1);
+	}
 
 }

--- a/testfiles/renamingmatchingonlymethoddecls/base.java
+++ b/testfiles/renamingmatchingonlymethoddecls/base.java
@@ -1,0 +1,11 @@
+import java.io.Serializable;
+import java.util.List;
+
+public class Test {
+	
+	private Object rep;
+	
+	public List<Object> ripf(Long l) {
+		return rep.ripf(l);
+	}
+}

--- a/testfiles/renamingmatchingonlymethoddecls/left.java
+++ b/testfiles/renamingmatchingonlymethoddecls/left.java
@@ -1,0 +1,12 @@
+import java.io.Serializable;
+import java.util.List;
+import javax.inject.Inject;
+
+public class Test {
+	
+	private Object rep;
+	
+	public List<Object> ripf(Long l) {
+		return rep.ripf(l);
+	}
+}

--- a/testfiles/renamingmatchingonlymethoddecls/right.java
+++ b/testfiles/renamingmatchingonlymethoddecls/right.java
@@ -1,0 +1,7 @@
+import java.util.List;
+
+public interface Test {
+
+	public List<Object> ripf(Long l);
+
+}

--- a/testfiles/renamingproperbodyofabstractmethods/base.java
+++ b/testfiles/renamingproperbodyofabstractmethods/base.java
@@ -1,0 +1,20 @@
+import java.io.Serializable;
+import java.util.List;
+
+public class Test {
+	
+	private Object rep;
+	
+	public Object m(Object e) {
+		//TODO a comment
+		int a;
+		int b;
+		int c;
+		return e;
+	}
+
+	
+	public List<Object> ripf(Long l) {
+		return rep.ripf(l);
+	}
+}

--- a/testfiles/renamingproperbodyofabstractmethods/left.java
+++ b/testfiles/renamingproperbodyofabstractmethods/left.java
@@ -1,0 +1,19 @@
+import java.io.Serializable;
+import java.util.List;
+import javax.inject.Inject;
+
+public class Test {
+	
+	private Object rep;
+	
+	public Object m(Object e) {
+		int a;
+		int b;
+		int c;
+		return e;
+	}
+	
+	public List<Object> ripf(Long l) {
+		return rep.ripf(l);
+	}
+}

--- a/testfiles/renamingproperbodyofabstractmethods/right.java
+++ b/testfiles/renamingproperbodyofabstractmethods/right.java
@@ -1,0 +1,7 @@
+import java.util.List;
+
+public interface Test {
+
+	public List<Object> ripf(Long l);
+
+}


### PR DESCRIPTION
- Fixes #135 a bug in which non-method/constructor declarations are being matched on MethodAndConstructorRenamingAndDeletionHandler handler
- Fixes #134 a bug in RenamingUtils which returns ";" as the body of abstract methods (should be empty)