### PR TITLE
no-conflicts git integration test bug fix

### DIFF
--- a/testfiles/shelltests/s3mGitIntegrationTests.java
+++ b/testfiles/shelltests/s3mGitIntegrationTests.java
@@ -206,8 +206,8 @@ public class s3mGitIntegrationTests {
         commitFiles(filesPath + "/right", "right");
         output.append(runProgram("git", "checkout", "master"));
 
-        output.append(runProgram("git", "merge", "left", "--no-edit"));
-        output.append(runProgram("git", "merge", "right", "--no-edit"));
+        output.append(runProgram("git", "merge", "left", "--no-edit", "-s", "recursive"));
+        output.append(runProgram("git", "merge", "right", "--no-edit", "-s", "recursive"));
         return output.toString();
     }
 


### PR DESCRIPTION
One of the **git** integration tests expected `git merge` to run with the **recursive** strategy. But **recursive** is not the default `git merge` strategy anymore, it is now **ort**. This PR fixes this test by explicitly running `git merge` with the **recursive** strategy