### PR TITLE
Bugfix/NullPointerException at renaming handler

### DIFF
--- a/src/main/java/br/ufpe/cin/mergers/handlers/renaming/SafelyMergeSimilarRenamingHandler.java
+++ b/src/main/java/br/ufpe/cin/mergers/handlers/renaming/SafelyMergeSimilarRenamingHandler.java
@@ -33,9 +33,10 @@ import de.ovgu.cide.fstgen.ast.FSTNode;
 public class SafelyMergeSimilarRenamingHandler implements RenamingHandler {
 
     @Override
-    public void handle(MergeContext context, Quartet<FSTNode, FSTNode, FSTNode, FSTNode> scenarioNodes)
-            throws TextualMergeException {
-
+    public void handle(
+        MergeContext context,
+        Quartet<FSTNode, FSTNode, FSTNode, FSTNode> scenarioNodes
+    ) throws TextualMergeException {
             // Only one developer renamed or deleted the method.    
             if(atMostSingleRenamingOrDeletion(scenarioNodes)) {
                 runTextualMergeOnNodes(context, scenarioNodes);
@@ -65,7 +66,10 @@ public class SafelyMergeSimilarRenamingHandler implements RenamingHandler {
      * @param scenarioNodes
      * @throws TextualMergeException
      */
-    private void runTextualMergeOnNodes(MergeContext context, Quartet<FSTNode, FSTNode, FSTNode, FSTNode> scenarioNodes) throws TextualMergeException {
+    private void runTextualMergeOnNodes(
+        MergeContext context,
+        Quartet<FSTNode, FSTNode, FSTNode, FSTNode> scenarioNodes
+    ) throws TextualMergeException {
         FSTNode leftNode = scenarioNodes.getValue0();
         FSTNode baseNode = scenarioNodes.getValue1();
         FSTNode rightNode = scenarioNodes.getValue2();
@@ -87,50 +91,76 @@ public class SafelyMergeSimilarRenamingHandler implements RenamingHandler {
      * @param scenarioNodes
      * @throws TextualMergeException
      */
-    private void handleDoubleRenaming(MergeContext context, Quartet<FSTNode, FSTNode, FSTNode, FSTNode> scenarioNodes) throws TextualMergeException {
+    private void handleDoubleRenaming(
+        MergeContext context,
+        Quartet<FSTNode, FSTNode, FSTNode, FSTNode> scenarioNodes
+    ) throws TextualMergeException {
         FSTNode leftNode = scenarioNodes.getValue0();
         FSTNode baseNode = scenarioNodes.getValue1();
         FSTNode rightNode = scenarioNodes.getValue2();
         FSTNode mergeNode = scenarioNodes.getValue3();
 
         if(RenamingUtils.haveDifferentSignature(leftNode, rightNode)) {
-            RenamingUtils.generateMutualRenamingConflict(context, leftNode, baseNode, rightNode, mergeNode,
-                    "double renaming to different signatures");
+            RenamingUtils.generateMutualRenamingConflict(
+                context, leftNode, baseNode, rightNode, mergeNode,
+                "double renaming to different signatures");
+        } else if(RenamingUtils.haveDifferentBody(leftNode, rightNode)) {
+            try {
+                if(thereIsNewReference(leftNode, rightNode, context)) {
+                    RenamingUtils.generateMutualRenamingConflict(
+                        context, leftNode, baseNode, rightNode, mergeNode,
+                        "addition of a new reference when both changed the method's body");
+                } else {
+                    RenamingUtils.runTextualMerge(context, leftNode, baseNode, rightNode, mergeNode);
+                }
+            } catch (CountReferencesVisitorException e) {
+
+            }  
         }
-
-        else if(RenamingUtils.haveDifferentBody(leftNode, rightNode)) {
-
-            if(thereIsNewReference(leftNode, context.getLeft(), context) || thereIsNewReference(rightNode, context.getRight(), context)) {
-                RenamingUtils.generateMutualRenamingConflict(context, leftNode, baseNode, rightNode, mergeNode,
-                    "addition of a new reference when both changed the method's body");
-            } 
-            
-            else {
-                RenamingUtils.runTextualMerge(context, leftNode, baseNode, rightNode, mergeNode);
-            }
-            
-        }
-
     }
 
-    private boolean thereIsNewReference(FSTNode toNode, File inFile, MergeContext context) {
+    private boolean thereIsNewReference(
+        FSTNode leftNode,
+        FSTNode rightNode,
+        MergeContext context
+    ) throws CountReferencesVisitorException {
+        boolean thereIs = thereIsNewReference(leftNode, context.getLeft(), context);
+        thereIs |= thereIsNewReference(rightNode, context.getRight(), context);
+        return thereIs;
+    }
+
+    private boolean thereIsNewReference(
+        FSTNode toNode,
+        File inFile,
+        MergeContext context
+    ) throws CountReferencesVisitorException {
         String signature = toNode.getName();
         int numberBaseReferences = countReferences(context.getBase(), signature);
         int numberContributionReferences = countReferences(inFile, signature);
         return numberContributionReferences > numberBaseReferences;
     }
 
-    private int countReferences(File file, String signature) {
+    private int countReferences(File file, String signature) throws CountReferencesVisitorException {
         String programSource = FilesManager.readFileContent(file);
         CompilationUnit compilationUnit = new JavaCompiler().compile(programSource);
-        
-        List<org.eclipse.jdt.core.dom.ASTNode> instances = new ArrayList<ASTNode>();
+
+        CountReferencesVisitor visitor = new CountReferencesVisitor(signature);
+        return visitor.countReferences(compilationUnit);
+
+        /* List<ASTNode> instances = new ArrayList<ASTNode>();
+
         compilationUnit.accept(new ASTVisitor() {
+            public boolean parserFailed = false;
             
             @Override
             public void endVisit(MethodInvocation node) {
-                if (sameSignatureAs(node, signature))
-                    instances.add(node);
+                try {
+                    if (sameSignatureAs(node, signature))
+                        instances.add(node);
+                } catch (RuntimeException e) {
+                    // The parser may fail at identifying an expression's type
+                    parserFailed = true;
+                }
             }
 
             private boolean sameSignatureAs(MethodInvocation node, String signature) {
@@ -149,7 +179,56 @@ public class SafelyMergeSimilarRenamingHandler implements RenamingHandler {
             }
 
         });
-        return instances.size();
+        return instances.size(); */
     }    
     
 }
+
+class CountReferencesVisitor extends ASTVisitor {
+    private final String methodName;
+    private final String[] methodParameters;
+    private List<ASTNode> instances;
+
+    public CountReferencesVisitor(String methodSignature) {
+        String[] nameAndParameters = methodSignature.split("[\\(\\)]");
+        this.methodName = nameAndParameters[0];
+        this.methodParameters = nameAndParameters[1].split("-");
+    }
+
+    public int countReferences(CompilationUnit compilationUnit) throws CountReferencesVisitorException {
+        try {
+            instances = new ArrayList<ASTNode>();
+            compilationUnit.accept(this);
+            return instances.size();
+        } catch (RuntimeException e) {
+            // Parser may fail at identifying an expression's type at argumentsMatchParameters
+            throw new CountReferencesVisitorException();
+        }
+    }
+
+    @Override
+    public void endVisit(MethodInvocation node) {
+        if (sameSignature(node))
+            instances.add(node);
+    }
+
+    private boolean sameSignature(MethodInvocation node) {
+        String currentMethodName = node.getName().toString();
+        return currentMethodName.equals(methodName) && argumentsMatchParameters(node.arguments());
+    }
+
+    private boolean argumentsMatchParameters(List arguments) {
+        for (int i = 0; i < arguments.size(); i++) {
+            Expression argument = (Expression) arguments.get(i);
+            String typeName = argument.resolveTypeBinding().getName();
+
+            // Twice because the FST parser replicates the parameters
+            if (!typeName.equals(methodParameters[i * 2]))
+                return false;
+        }
+
+        return true;
+    }
+}
+
+class CountReferencesVisitorException extends Exception {}


### PR DESCRIPTION
The tool could throw `NullPointerException` during the renaming handler execution, due to the parser not being able to determine an expression's type in `sameArgumentList`. This PR fixes it by catching the exception and looking for conflicts reported by the unstructured merge approach involving the renamed method's signature. If it finds such a conflict, it also reports a conflict, otherwise not. That way, the tool will always perform at least as good as the unstructured merge approach.