### PR TITLE
Bugfix/Renaming Conflicts Statistics

### DIFF
--- a/src/main/java/br/ufpe/cin/mergers/handlers/MethodAndConstructorRenamingAndDeletionHandler.java
+++ b/src/main/java/br/ufpe/cin/mergers/handlers/MethodAndConstructorRenamingAndDeletionHandler.java
@@ -100,7 +100,7 @@ public final class MethodAndConstructorRenamingAndDeletionHandler implements Con
 	}
 
 	private boolean isInContribution(FSTNode node, FSTNode contributionTree) {
-		return Traverser.isInTree(node, contributionTree);
+		return Traverser.isInTree(node.getType(), node.getName(), contributionTree);
 	}
 
 	private boolean matchesWithEqualBody(FSTNode baseNode, List<FSTNode> addedNodes) {

--- a/src/main/java/br/ufpe/cin/mergers/util/MergeContext.java
+++ b/src/main/java/br/ufpe/cin/mergers/util/MergeContext.java
@@ -2,7 +2,9 @@ package br.ufpe.cin.mergers.util;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.Triple;
@@ -54,7 +56,6 @@ public class MergeContext {
 
 	//statistics
 	public int newElementReferencingEditedOneConflicts = 0;
-	public int renamingConflicts = 0;
 	public int typeAmbiguityErrorsConflicts = 0;
 	public int deletionConflicts = 0;
 	public int innerDeletionConflicts = 0;
@@ -69,6 +70,8 @@ public class MergeContext {
 	public int orderingConflicts 			   = 0;
 	public int duplicatedDeclarationErrors	   = 0;
 	public int equalConflicts     = 0;
+	public int renamingConflicts = 0;
+	public Set<FSTNode> renamingVisitedMergeNodes = new HashSet<>();
 
 	public MergeContext(){
 	}

--- a/src/main/java/br/ufpe/cin/mergers/util/Traverser.java
+++ b/src/main/java/br/ufpe/cin/mergers/util/Traverser.java
@@ -57,6 +57,8 @@ public class Traverser {
     }
 
     public static FSTNode retrieveNodeFromTree(FSTNode node, FSTNode tree) {
+        if (node == null) return null;
+        
         List<FSTNode> nodes = collectNodes(tree);
         for (FSTNode treeNode : nodes) {
             if(treeNode.getName().equals(node.getName()))

--- a/src/main/java/br/ufpe/cin/mergers/util/Traverser.java
+++ b/src/main/java/br/ufpe/cin/mergers/util/Traverser.java
@@ -13,10 +13,41 @@ import de.ovgu.cide.fstgen.ast.FSTTerminal;
  */
 public class Traverser {
 
+    /**
+     * Compares all nodes in {@code tree} to {@code node} by
+     * reference to find out if this exact node is in the tree
+     * 
+     * @param node
+     * @param tree
+     * @return true if node is in tree, false otherwise
+    */
     public static boolean isInTree(FSTNode node, FSTNode tree) {
         List<FSTNode> nodes = collectNodes(tree);
-        return nodes.contains(node);
-    }    
+        for (FSTNode n: nodes)
+            if (n == node)
+                return true;
+
+        return false;
+    }
+
+    /**
+     * Compares all nodes types and names in {@code tree} to a
+     * given node's {@code type} and {@code name} to find out if
+     * there is a node in {@code tree} matching given node's parameters
+     * 
+     * @param type
+     * @param name
+     * @param tree
+     * @return true if a match was found, false otherwise
+     */
+    public static boolean isInTree(String type, String name, FSTNode tree) {
+        List<FSTNode> nodes = collectNodes(tree);
+        for (FSTNode node: nodes)
+            if (node.getType().equals(type) && node.getName().equals(name))
+                return true;
+
+        return false;
+    }
 
     public static List<FSTTerminal> collectTerminals(FSTNode tree) {
         return collectNodes(tree).stream()


### PR DESCRIPTION
The tool wasn't counting the number of renaming conflicts properly, making it report, in some occasions, that the number of renaming conflicts was greater than the number of total conflicts. This PR fixes it by maintaining the number of renaming conflicts up to date during the execution of the renaming handler.